### PR TITLE
breaking: Rework event data.

### DIFF
--- a/crates/events/src/emitter.rs
+++ b/crates/events/src/emitter.rs
@@ -51,24 +51,27 @@ impl<E: Event + 'static> Emitter<E> {
     ///
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
-    pub async fn emit(&self, event: E) -> miette::Result<(E, Option<E::Value>)> {
-        let mut result = None;
+    pub async fn emit(&self, event: E) -> miette::Result<EmitResult<E>> {
+        let mut return_value = None;
         let mut remove_indices = HashSet::new();
-        let event = Arc::new(RwLock::new(event));
         let mut subscribers = self.subscribers.write().await;
+
+        let event = Arc::new(event);
+        let data = Arc::new(RwLock::new(E::Data::default()));
 
         for (index, subscriber) in subscribers.iter_mut().enumerate() {
             let event = Arc::clone(&event);
+            let data = Arc::clone(&data);
 
             if subscriber.is_once() {
                 remove_indices.insert(index);
             }
 
-            match subscriber.on_emit(event).await? {
+            match subscriber.on_emit(event, data).await? {
                 EventState::Continue => continue,
                 EventState::Stop => break,
                 EventState::Return(value) => {
-                    result = Some(value);
+                    return_value = Some(value);
                     break;
                 }
             }
@@ -83,8 +86,10 @@ impl<E: Event + 'static> Emitter<E> {
             !remove
         });
 
-        let event = Arc::into_inner(event).unwrap().into_inner();
-
-        Ok((event, result))
+        Ok(EmitResult {
+            event: Arc::into_inner(event).unwrap(),
+            data: Arc::into_inner(data).unwrap().into_inner(),
+            value: return_value,
+        })
     }
 }

--- a/crates/events/src/emitter.rs
+++ b/crates/events/src/emitter.rs
@@ -51,7 +51,7 @@ impl<E: Event + 'static> Emitter<E> {
     ///
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
-    pub async fn emit(&self, event: E) -> miette::Result<(E, E::Data)> {
+    pub async fn emit(&self, event: E) -> miette::Result<E::Data> {
         let mut remove_indices = HashSet::new();
         let mut subscribers = self.subscribers.write().await;
 
@@ -81,9 +81,6 @@ impl<E: Event + 'static> Emitter<E> {
             !remove
         });
 
-        let event = Arc::into_inner(event).unwrap();
-        let data = Arc::into_inner(data).unwrap().into_inner();
-
-        Ok((event, data))
+        Ok(Arc::into_inner(data).unwrap().into_inner())
     }
 }

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,18 +1,10 @@
 pub trait Event: Send + Sync {
     type Data: Send + Sync + Default;
-    type ReturnValue;
 }
 
-pub enum EventState<V> {
+pub enum EventState {
     Continue,
     Stop,
-    Return(V),
 }
 
-pub type EventResult<E> = miette::Result<EventState<<E as Event>::ReturnValue>>;
-
-pub struct EmitResult<E: Event> {
-    pub event: E,
-    pub data: E::Data,
-    pub value: Option<E::ReturnValue>,
-}
+pub type EventResult = miette::Result<EventState>;

--- a/crates/events/src/event.rs
+++ b/crates/events/src/event.rs
@@ -1,5 +1,6 @@
 pub trait Event: Send + Sync {
-    type Value;
+    type Data: Send + Sync + Default;
+    type ReturnValue;
 }
 
 pub enum EventState<V> {
@@ -8,4 +9,10 @@ pub enum EventState<V> {
     Return(V),
 }
 
-pub type EventResult<E> = miette::Result<EventState<<E as Event>::Value>>;
+pub type EventResult<E> = miette::Result<EventState<<E as Event>::ReturnValue>>;
+
+pub struct EmitResult<E: Event> {
+    pub event: E,
+    pub data: E::Data,
+    pub value: Option<E::ReturnValue>,
+}

--- a/crates/events/src/subscriber.rs
+++ b/crates/events/src/subscriber.rs
@@ -7,24 +7,24 @@ use tokio::sync::RwLock;
 #[async_trait]
 pub trait Subscriber<E: Event>: Send + Sync {
     fn is_once(&self) -> bool;
-    async fn on_emit(&mut self, event: Arc<RwLock<E>>) -> EventResult<E>;
+    async fn on_emit(&mut self, event: Arc<E>, data: Arc<RwLock<E::Data>>) -> EventResult<E>;
 }
 
 pub type BoxedSubscriber<E> = Box<dyn Subscriber<E>>;
 
 #[async_trait]
 pub trait SubscriberFunc<E: Event>: Send + Sync {
-    async fn call(&self, event: Arc<RwLock<E>>) -> EventResult<E>;
+    async fn call(&self, event: Arc<E>, data: Arc<RwLock<E::Data>>) -> EventResult<E>;
 }
 
 #[async_trait]
 impl<T: Send + Sync, E: Event + 'static, F> SubscriberFunc<E> for T
 where
-    T: Fn(Arc<RwLock<E>>) -> F,
+    T: Fn(Arc<E>, Arc<RwLock<E::Data>>) -> F,
     F: Future<Output = EventResult<E>> + Send,
 {
-    async fn call(&self, event: Arc<RwLock<E>>) -> EventResult<E> {
-        self(event).await
+    async fn call(&self, event: Arc<E>, data: Arc<RwLock<E::Data>>) -> EventResult<E> {
+        self(event, data).await
     }
 }
 
@@ -48,7 +48,7 @@ impl<E: Event> Subscriber<E> for CallbackSubscriber<E> {
         self.once
     }
 
-    async fn on_emit(&mut self, event: Arc<RwLock<E>>) -> EventResult<E> {
-        self.func.call(event).await
+    async fn on_emit(&mut self, event: Arc<E>, data: Arc<RwLock<E::Data>>) -> EventResult<E> {
+        self.func.call(event, data).await
     }
 }

--- a/crates/events/tests/event_macros_test.rs
+++ b/crates/events/tests/event_macros_test.rs
@@ -17,62 +17,56 @@ enum TestError {
     Test,
 }
 
-#[derive(Event)]
-#[event(value = "i32")]
+#[derive(Debug, Event)]
+#[event(dataset = i32)]
 struct IntEvent(pub i32);
 
 #[derive(Event)]
-#[event(value = "String")]
+#[event(dataset = String)]
 struct StringEvent(pub String);
 
 #[derive(Event)]
-#[event(value = "PathBuf")]
+#[event(dataset = PathBuf)]
 struct PathEvent(pub PathBuf);
 
 #[derive(Event)]
-#[event(value = "std::path::PathBuf")]
+#[event(dataset = std::path::PathBuf)]
 struct FQPathEvent(pub PathBuf);
 
-async fn callback_func(event: Arc<RwLock<IntEvent>>) -> EventResult<IntEvent> {
-    let mut event = event.write().await;
-    event.0 += 5;
+async fn callback_func(_event: Arc<IntEvent>, data: Arc<RwLock<i32>>) -> EventResult {
+    let mut data = data.write().await;
+    *data += 5;
     Ok(EventState::Continue)
 }
 
 #[subscriber]
-async fn callback_read(event: IntEvent) -> EventResult<IntEvent> {
-    dbg!(event.0);
+async fn callback_read(data: IntEvent) -> EventResult {
+    dbg!(event, data);
 }
 
 #[subscriber]
-async fn callback_write(mut event: IntEvent) -> EventResult<IntEvent> {
-    event.0 += 5;
+async fn callback_write(mut data: IntEvent) -> EventResult {
+    *data += 5;
     Ok(EventState::Continue)
 }
 
 #[subscriber]
-async fn callback_write_ref(event: &mut IntEvent) -> EventResult<IntEvent> {
-    event.0 += 5;
+async fn callback_write_ref(data: &mut IntEvent) -> EventResult {
+    *data += 5;
 }
 
 #[subscriber]
-fn callback_return(event: &mut IntEvent) {
-    event.0 += 5;
+fn callback_return(data: &mut IntEvent) {
+    *data += 5;
     Ok(EventState::Stop)
 }
 
 #[subscriber]
-async fn no_return(event: &mut IntEvent) -> EventResult<IntEvent> {
-    event.0 += 5;
+async fn no_return(data: &mut IntEvent) -> EventResult {
+    *data += 5;
 }
 
 #[subscriber]
-async fn custom_return(event: &mut IntEvent) -> EventResult<IntEvent> {
-    event.0 += 5;
-    Ok(EventState::Return(123))
-}
-
-#[subscriber]
-async fn err_return(_event: IntEvent) -> EventResult<IntEvent> {
+async fn err_return(_data: IntEvent) -> EventResult {
     Err(TestError::Test.into())
 }

--- a/crates/events/tests/events_test.rs
+++ b/crates/events/tests/events_test.rs
@@ -9,7 +9,7 @@ mod starbase {
 }
 
 #[derive(Event)]
-#[event(value = "i32")]
+#[event(dataset = i32)]
 struct TestEvent(pub i32);
 
 #[derive(Debug)]
@@ -23,8 +23,8 @@ impl Subscriber<TestEvent> for TestSubscriber {
         false
     }
 
-    async fn on_emit(&mut self, event: Arc<RwLock<TestEvent>>) -> EventResult<TestEvent> {
-        event.write().await.0 += self.inc;
+    async fn on_emit(&mut self, _event: Arc<TestEvent>, data: Arc<RwLock<i32>>) -> EventResult {
+        *(data.write().await) += self.inc;
         Ok(EventState::Continue)
     }
 }
@@ -38,8 +38,8 @@ impl Subscriber<TestEvent> for TestOnceSubscriber {
         true
     }
 
-    async fn on_emit(&mut self, event: Arc<RwLock<TestEvent>>) -> EventResult<TestEvent> {
-        event.write().await.0 += 3;
+    async fn on_emit(&mut self, _event: Arc<TestEvent>, data: Arc<RwLock<i32>>) -> EventResult {
+        *(data.write().await) += 3;
         Ok(EventState::Continue)
     }
 }
@@ -55,23 +55,9 @@ impl Subscriber<TestEvent> for TestStopSubscriber {
         false
     }
 
-    async fn on_emit(&mut self, event: Arc<RwLock<TestEvent>>) -> EventResult<TestEvent> {
-        event.write().await.0 += self.inc;
+    async fn on_emit(&mut self, _event: Arc<TestEvent>, data: Arc<RwLock<i32>>) -> EventResult {
+        *(data.write().await) += self.inc;
         Ok(EventState::Stop)
-    }
-}
-
-#[derive(Debug)]
-struct TestReturnSubscriber;
-
-#[async_trait]
-impl Subscriber<TestEvent> for TestReturnSubscriber {
-    fn is_once(&self) -> bool {
-        false
-    }
-
-    async fn on_emit(&mut self, _event: Arc<RwLock<TestEvent>>) -> EventResult<TestEvent> {
-        Ok(EventState::Return(0))
     }
 }
 
@@ -82,23 +68,10 @@ async fn subscriber() {
     emitter.subscribe(TestSubscriber { inc: 2 }).await;
     emitter.subscribe(TestSubscriber { inc: 3 }).await;
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 6);
-    assert_eq!(result, None);
-}
-
-#[tokio::test]
-async fn subscriber_return() {
-    let emitter = Emitter::<TestEvent>::new();
-    emitter.subscribe(TestSubscriber { inc: 1 }).await;
-    emitter.subscribe(TestSubscriber { inc: 2 }).await;
-    emitter.subscribe(TestReturnSubscriber).await;
-
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
-
-    assert_eq!(event.0, 3);
-    assert_eq!(result, Some(0));
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 6);
 }
 
 #[tokio::test]
@@ -108,10 +81,10 @@ async fn subscriber_stop() {
     emitter.subscribe(TestStopSubscriber { inc: 2 }).await;
     emitter.subscribe(TestSubscriber { inc: 3 }).await;
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 3);
-    assert_eq!(result, None);
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 3);
 }
 
 #[tokio::test]
@@ -123,57 +96,52 @@ async fn subscriber_once() {
 
     assert_eq!(emitter.len().await, 3);
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
-
-    assert_eq!(event.0, 9);
-    assert_eq!(result, None);
-    assert_eq!(emitter.len().await, 0);
-
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
     assert_eq!(event.0, 0);
-    assert_eq!(result, None);
+    assert_eq!(data, 9);
+    assert_eq!(emitter.len().await, 0);
+
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 0);
     assert_eq!(emitter.len().await, 0);
 }
 
-// async fn callback_func(event: Arc<RwLock<TestEvent>>) -> EventResult<TestEvent> {
+// async fn callback_func(event: Arc<RwLock<TestEvent>>) -> EventResult {
 //     let mut event = event.write().await;
 //     event.0 += 5;
 //     Ok(EventState::Continue)
 // }
 
 #[subscriber]
-async fn callback_one(event: &mut TestEvent) -> EventResult<TestEvent> {
-    event.0 += 1;
+async fn callback_one(data: &mut TestEvent) -> EventResult {
+    *data += 1;
     Ok(EventState::Continue)
 }
 
 #[subscriber]
-async fn callback_two(mut event: TestEvent) -> EventResult<TestEvent> {
-    event.0 += 2;
+async fn callback_two(mut data: TestEvent) -> EventResult {
+    *data += 2;
     Ok(EventState::Continue)
 }
 
 #[subscriber]
-async fn callback_three(event: &mut TestEvent) {
-    event.0 += 3;
+async fn callback_three(data: &mut TestEvent) {
+    *data += 3;
     Ok(EventState::Continue)
 }
 
 #[subscriber]
-async fn callback_return(_event: TestEvent) {
-    Ok(EventState::Return(0))
-}
-
-#[subscriber]
-async fn callback_stop(event: &mut TestEvent) -> EventResult<TestEvent> {
-    event.0 += 2;
+async fn callback_stop(data: &mut TestEvent) -> EventResult {
+    *data += 2;
     Ok(EventState::Stop)
 }
 
 #[subscriber]
-async fn callback_once(mut event: TestEvent) -> EventResult<TestEvent> {
-    event.0 += 3;
+async fn callback_once(mut data: TestEvent) -> EventResult {
+    *data += 3;
     Ok(EventState::Continue)
 }
 
@@ -184,23 +152,10 @@ async fn callbacks() {
     emitter.on(callback_two).await;
     emitter.on(callback_three).await;
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 6);
-    assert_eq!(result, None);
-}
-
-#[tokio::test]
-async fn callbacks_return() {
-    let emitter = Emitter::<TestEvent>::new();
-    emitter.on(callback_one).await;
-    emitter.on(callback_two).await;
-    emitter.on(callback_return).await;
-
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
-
-    assert_eq!(event.0, 3);
-    assert_eq!(result, Some(0));
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 6);
 }
 
 #[tokio::test]
@@ -210,10 +165,10 @@ async fn callbacks_stop() {
     emitter.on(callback_stop).await;
     emitter.on(callback_three).await;
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 3);
-    assert_eq!(result, None);
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 3);
 }
 
 #[tokio::test]
@@ -225,16 +180,16 @@ async fn callbacks_once() {
 
     assert_eq!(emitter.len().await, 3);
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
-
-    assert_eq!(event.0, 9);
-    assert_eq!(result, None);
-    assert_eq!(emitter.len().await, 0);
-
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
     assert_eq!(event.0, 0);
-    assert_eq!(result, None);
+    assert_eq!(data, 9);
+    assert_eq!(emitter.len().await, 0);
+
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 0);
     assert_eq!(emitter.len().await, 0);
 }
 
@@ -249,16 +204,16 @@ async fn preserves_onces_that_didnt_run() {
 
     assert_eq!(emitter.len().await, 5);
 
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 8);
-    assert_eq!(result, None);
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 8);
     assert_eq!(emitter.len().await, 3);
 
     // Will stop immediately
-    let (event, result) = emitter.emit(TestEvent(0)).await.unwrap();
+    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
     assert_eq!(event.0, 2);
-    assert_eq!(result, None);
+    assert_eq!(data, 0);
     assert_eq!(emitter.len().await, 3);
 }

--- a/crates/events/tests/events_test.rs
+++ b/crates/events/tests/events_test.rs
@@ -68,9 +68,8 @@ async fn subscriber() {
     emitter.subscribe(TestSubscriber { inc: 2 }).await;
     emitter.subscribe(TestSubscriber { inc: 3 }).await;
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 6);
 }
 
@@ -81,9 +80,8 @@ async fn subscriber_stop() {
     emitter.subscribe(TestStopSubscriber { inc: 2 }).await;
     emitter.subscribe(TestSubscriber { inc: 3 }).await;
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 3);
 }
 
@@ -96,15 +94,13 @@ async fn subscriber_once() {
 
     assert_eq!(emitter.len().await, 3);
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 9);
     assert_eq!(emitter.len().await, 0);
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 0);
     assert_eq!(emitter.len().await, 0);
 }
@@ -152,9 +148,8 @@ async fn callbacks() {
     emitter.on(callback_two).await;
     emitter.on(callback_three).await;
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 6);
 }
 
@@ -165,9 +160,8 @@ async fn callbacks_stop() {
     emitter.on(callback_stop).await;
     emitter.on(callback_three).await;
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 3);
 }
 
@@ -180,15 +174,13 @@ async fn callbacks_once() {
 
     assert_eq!(emitter.len().await, 3);
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 9);
     assert_eq!(emitter.len().await, 0);
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 0);
     assert_eq!(emitter.len().await, 0);
 }
@@ -204,16 +196,44 @@ async fn preserves_onces_that_didnt_run() {
 
     assert_eq!(emitter.len().await, 5);
 
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 8);
     assert_eq!(emitter.len().await, 3);
 
     // Will stop immediately
-    let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
+    let data = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 0);
     assert_eq!(data, 2);
     assert_eq!(emitter.len().await, 3);
 }
+
+// #[derive(Event)]
+// #[event(dataset = String)]
+// struct TestRefEvent<'e> {
+//     pub name: &'e str,
+//     pub path: &'e Path,
+// }
+
+// #[subscriber]
+// async fn ref_callback(data: &mut TestRefEvent<'_>) -> EventResult {
+//     (*data).push_str(event.name);
+//     Ok(EventState::Continue)
+// }
+
+// #[tokio::test]
+// async fn supports_lifetime_references() {
+//     let emitter = Emitter::<TestRefEvent>::new();
+//     emitter.on(ref_callback).await;
+
+//     let name = String::from("foo");
+//     let path = PathBuf::from("/");
+//     let event = TestRefEvent {
+//         name: &name,
+//         path: &path,
+//     };
+
+//     let data = emitter.emit(event).await.unwrap();
+
+//     assert_eq!(data, "foo");
+// }

--- a/crates/events/tests/events_test.rs
+++ b/crates/events/tests/events_test.rs
@@ -213,7 +213,7 @@ async fn preserves_onces_that_didnt_run() {
     // Will stop immediately
     let (event, data) = emitter.emit(TestEvent(0)).await.unwrap();
 
-    assert_eq!(event.0, 2);
-    assert_eq!(data, 0);
+    assert_eq!(event.0, 0);
+    assert_eq!(data, 2);
     assert_eq!(emitter.len().await, 3);
 }

--- a/crates/framework/src/emitters.rs
+++ b/crates/framework/src/emitters.rs
@@ -20,7 +20,7 @@ impl EmitterManager {
     ///
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
-    pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<(E, E::Data)> {
+    pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<E::Data> {
         self.get::<Emitter<E>>().emit(event).await
     }
 }

--- a/crates/framework/src/emitters.rs
+++ b/crates/framework/src/emitters.rs
@@ -5,9 +5,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub use starbase_events::{
-    EmitResult, Emitter, Event, EventResult, EventState, Subscriber, SubscriberFunc,
-};
+pub use starbase_events::{Emitter, Event, EventResult, EventState, Subscriber, SubscriberFunc};
 
 create_instance_manager!(EmitterManager, EmitterInstance);
 
@@ -22,7 +20,7 @@ impl EmitterManager {
     ///
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
-    pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<EmitResult<E>> {
+    pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<(E, E::Data)> {
         self.get::<Emitter<E>>().emit(event).await
     }
 }

--- a/crates/framework/src/emitters.rs
+++ b/crates/framework/src/emitters.rs
@@ -5,7 +5,9 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-pub use starbase_events::{Emitter, Event, EventResult, EventState, Subscriber, SubscriberFunc};
+pub use starbase_events::{
+    EmitResult, Emitter, Event, EventResult, EventState, Subscriber, SubscriberFunc,
+};
 
 create_instance_manager!(EmitterManager, EmitterInstance);
 
@@ -20,10 +22,7 @@ impl EmitterManager {
     ///
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
-    pub async fn emit<E: Event + 'static>(
-        &self,
-        event: E,
-    ) -> miette::Result<(E, Option<E::Value>)> {
+    pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<EmitResult<E>> {
         self.get::<Emitter<E>>().emit(event).await
     }
 }

--- a/crates/framework/tests/instances_test.rs
+++ b/crates/framework/tests/instances_test.rs
@@ -10,7 +10,7 @@ mod events {
 
     #[subscriber]
     async fn callback_one(mut data: TestEvent) -> EventResult<TestEvent> {
-        *data += 5;
+        *data += 5 + event.0;
         Ok(EventState::Continue)
     }
 
@@ -22,9 +22,10 @@ mod events {
         let em = ctx.get_mut::<Emitter<TestEvent>>();
         em.on(callback_one).await;
 
-        let (event, _) = em.emit(TestEvent(5)).await.unwrap();
+        let (event, data) = em.emit(TestEvent(5)).await.unwrap();
 
-        assert_eq!(event.0, 10);
+        assert_eq!(event.0, 5);
+        assert_eq!(data, 10);
     }
 }
 

--- a/crates/framework/tests/instances_test.rs
+++ b/crates/framework/tests/instances_test.rs
@@ -9,7 +9,7 @@ mod events {
     struct TestEvent(pub usize);
 
     #[subscriber]
-    async fn callback_one(mut data: TestEvent) -> EventResult<TestEvent> {
+    async fn callback_one(mut data: TestEvent) -> EventResult {
         *data += 5 + event.0;
         Ok(EventState::Continue)
     }
@@ -22,9 +22,8 @@ mod events {
         let em = ctx.get_mut::<Emitter<TestEvent>>();
         em.on(callback_one).await;
 
-        let (event, data) = em.emit(TestEvent(5)).await.unwrap();
+        let data = em.emit(TestEvent(5)).await.unwrap();
 
-        assert_eq!(event.0, 5);
         assert_eq!(data, 10);
     }
 }

--- a/crates/framework/tests/instances_test.rs
+++ b/crates/framework/tests/instances_test.rs
@@ -5,11 +5,12 @@ mod events {
     use super::*;
 
     #[derive(Debug, Event)]
+    #[event(dataset = usize)]
     struct TestEvent(pub usize);
 
     #[subscriber]
-    async fn callback_one(mut event: TestEvent) -> EventResult<TestEvent> {
-        event.0 += 5;
+    async fn callback_one(mut data: TestEvent) -> EventResult<TestEvent> {
+        *data += 5;
         Ok(EventState::Continue)
     }
 

--- a/crates/macros/src/event.rs
+++ b/crates/macros/src/event.rs
@@ -7,24 +7,17 @@ use syn::{parse_macro_input, DeriveInput, ExprPath};
 #[darling(default, attributes(event))]
 struct EventArgs {
     dataset: Option<ExprPath>,
-    value: Option<ExprPath>,
 }
 
 // #[derive(Event)]
 // #[event]
-// #[event(value = "String")]
+// #[event(data = String)]
 pub fn macro_impl(item: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(item);
     let args = EventArgs::from_derive_input(&input).expect("Failed to parse arguments.");
 
     let struct_name = input.ident;
-
     let data_type = match args.dataset {
-        Some(value) => quote! { #value },
-        None => quote! { () },
-    };
-
-    let value_type = match args.value {
         Some(value) => quote! { #value },
         None => quote! { () },
     };
@@ -33,7 +26,6 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
         #[automatically_derived]
         impl starbase::Event for #struct_name {
             type Data = #data_type;
-            type ReturnValue = #value_type;
         }
     }
     .into()

--- a/crates/macros/src/event.rs
+++ b/crates/macros/src/event.rs
@@ -1,12 +1,13 @@
 use darling::FromDeriveInput;
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Type};
+use syn::{parse_macro_input, DeriveInput, ExprPath};
 
 #[derive(FromDeriveInput, Default)]
 #[darling(default, attributes(event))]
 struct EventArgs {
-    value: Option<Type>,
+    dataset: Option<ExprPath>,
+    value: Option<ExprPath>,
 }
 
 // #[derive(Event)]
@@ -17,6 +18,12 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
     let args = EventArgs::from_derive_input(&input).expect("Failed to parse arguments.");
 
     let struct_name = input.ident;
+
+    let data_type = match args.dataset {
+        Some(value) => quote! { #value },
+        None => quote! { () },
+    };
+
     let value_type = match args.value {
         Some(value) => quote! { #value },
         None => quote! { () },
@@ -25,7 +32,8 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
     quote! {
         #[automatically_derived]
         impl starbase::Event for #struct_name {
-            type Value = #value_type;
+            type Data = #data_type;
+            type ReturnValue = #value_type;
         }
     }
     .into()

--- a/crates/macros/src/event.rs
+++ b/crates/macros/src/event.rs
@@ -17,6 +17,7 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
     let args = EventArgs::from_derive_input(&input).expect("Failed to parse arguments.");
 
     let struct_name = input.ident;
+    let generics = input.generics;
     let data_type = match args.dataset {
         Some(value) => quote! { #value },
         None => quote! { () },
@@ -24,7 +25,7 @@ pub fn macro_impl(item: TokenStream) -> TokenStream {
 
     quote! {
         #[automatically_derived]
-        impl starbase::Event for #struct_name {
+        impl #generics starbase::Event for #struct_name #generics {
             type Data = #data_type;
         }
     }

--- a/crates/macros/src/subscriber.rs
+++ b/crates/macros/src/subscriber.rs
@@ -87,7 +87,7 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
         panic!("Unsupported param, must be an identifier.");
     };
 
-    let event_name = &event_param_name.ident;
+    let data_name = &event_param_name.ident;
     let mut event_type = TypePath::from_string("Event").unwrap();
     let mut is_mutable = event_param_name.mutability.is_some();
 
@@ -110,9 +110,9 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
     };
 
     let acquire_lock = if is_mutable {
-        quote! { let mut #event_name = #event_name.write().await; }
+        quote! { let mut #data_name = #data_name.write().await; }
     } else {
-        quote! { let #event_name = #event_name.read().await; }
+        quote! { let #data_name = #data_name.read().await; }
     };
 
     let return_flow = if has_return_statement(&func_body) {
@@ -133,8 +133,8 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
         #attributes
         async fn #func_name(
             event: std::sync::Arc<#event_type>,
-            #event_name: std::sync::Arc<tokio::sync::RwLock<<#event_type as starbase::Event>::Data>>
-        ) -> starbase::EventResult<#event_type> {
+            #data_name: std::sync::Arc<tokio::sync::RwLock<<#event_type as starbase::Event>::Data>>
+        ) -> starbase::EventResult {
             #acquire_lock
             #func_body
             #return_flow

--- a/crates/macros/src/subscriber.rs
+++ b/crates/macros/src/subscriber.rs
@@ -132,7 +132,8 @@ pub fn macro_impl(_args: TokenStream, item: TokenStream) -> TokenStream {
     quote! {
         #attributes
         async fn #func_name(
-            #event_name: std::sync::Arc<tokio::sync::RwLock<#event_type>>
+            event: std::sync::Arc<#event_type>,
+            #event_name: std::sync::Arc<tokio::sync::RwLock<<#event_type as starbase::Event>::Data>>
         ) -> starbase::EventResult<#event_type> {
             #acquire_lock
             #func_body

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -16,11 +16,12 @@ enum AppError {
 struct TestState(pub String);
 
 #[derive(Debug, Event)]
-struct TestEvent(pub usize);
+#[event(dataset = usize)]
+struct TestEvent;
 
 #[subscriber]
-async fn update_event(mut event: TestEvent) {
-    event.0 = 100;
+async fn update_event(mut data: TestEvent) {
+    *data = 100;
 }
 
 #[system]
@@ -57,9 +58,9 @@ async fn analyze_one(state: StateMut<TestState>, em: EmitterRef<TestEvent>) {
     info!(val = state.0, "analyze {}", "foo.bar".style(Style::File));
     **state = "mutated".to_string();
 
-    let event = TestEvent(50);
+    let event = TestEvent;
     // dbg!(&event);
-    let (_, _) = em.emit(event).await.unwrap();
+    let (_, _data) = em.emit(event).await.unwrap();
     // dbg!(event);
 }
 

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -60,7 +60,7 @@ async fn analyze_one(state: StateMut<TestState>, em: EmitterRef<TestEvent>) {
 
     let event = TestEvent;
     // dbg!(&event);
-    let (_, _data) = em.emit(event).await.unwrap();
+    let _data = em.emit(event).await.unwrap();
     // dbg!(event);
 }
 


### PR DESCRIPTION
Previously the event itself was mutable, so you could modify fields and treat htem as the event data. However in practice, this resulted in an event being immutable and mutable at the same time, causing a lot of issues.

This change splits event data into its own parameter, entirely distinct from the event. Now event is read only, while data is read/write. Because of this change, I also removed the return value logic, since it's no longer necessary.