### PR TITLE
new: Use `Box` for better archive APIs.

### DIFF
--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -11,7 +11,9 @@ all-features = true
 
 [dependencies]
 starbase_styles = { version = "0.1.12", path = "../styles" }
-starbase_utils = { version = "0.2.16", path = "../utils" }
+starbase_utils = { version = "0.2.16", path = "../utils", default-features = false, features = [
+	"glob",
+] }
 miette = { workspace = true }
 rustc-hash = { workspace = true }
 tracing = { workspace = true }

--- a/crates/archive/src/archive.rs
+++ b/crates/archive/src/archive.rs
@@ -78,7 +78,7 @@ impl<'owner> Archiver<'owner> {
 
     pub fn pack<F, P>(&self, packer: F) -> miette::Result<()>
     where
-        F: FnOnce(&Path, &Path) -> miette::Result<P>,
+        F: FnOnce(&Path) -> miette::Result<P>,
         P: ArchivePacker,
     {
         trace!(
@@ -87,7 +87,7 @@ impl<'owner> Archiver<'owner> {
             "Packing archive",
         );
 
-        let mut archive = packer(self.source_root, self.archive_file)?;
+        let mut archive = packer(self.archive_file)?;
 
         for (source, file) in &self.source_files {
             if !source.exists() {

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -2,7 +2,7 @@ use crate::archive::{ArchivePacker, ArchiveUnpacker};
 use crate::tree_differ::TreeDiffer;
 use miette::Diagnostic;
 use starbase_styles::{Style, Stylize};
-use starbase_utils::fs::{self, FsError};
+use starbase_utils::fs;
 use std::io::{prelude::*, Write};
 use std::path::{Path, PathBuf};
 use tar::{Archive as TarArchive, Builder as TarBuilder};
@@ -10,10 +10,6 @@ use thiserror::Error;
 
 #[derive(Error, Diagnostic, Debug)]
 pub enum TarError {
-    #[diagnostic(transparent)]
-    #[error(transparent)]
-    Fs(#[from] FsError),
-
     #[diagnostic(code(tar::pack::add))]
     #[error("Failed to add source {} to archive.", .source.style(Style::Path))]
     AddFailure {

--- a/crates/archive/src/tree_differ.rs
+++ b/crates/archive/src/tree_differ.rs
@@ -128,7 +128,7 @@ impl TreeDiffer {
         let mut dest = fs::open_file(dest_path)?;
 
         if self.are_files_equal(source, &mut dest) {
-            return Ok(true);
+            return Ok(false);
         }
 
         // Reset read pointer to the start of the buffer

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -13,10 +13,6 @@ use zip::{result::ZipError as BaseZipError, CompressionMethod, ZipArchive, ZipWr
 
 #[derive(Error, Diagnostic, Debug)]
 pub enum ZipError {
-    #[diagnostic(transparent)]
-    #[error(transparent)]
-    Fs(#[from] FsError),
-
     #[diagnostic(code(zip::pack::add))]
     #[error("Failed to add source {} to archive.", .source.style(Style::Path))]
     AddFailure {
@@ -81,11 +77,9 @@ impl ArchivePacker for ZipPacker {
 
         self.archive
             .write_all(fs::read_file(file)?.as_bytes())
-            .map_err(|error| {
-                ZipError::Fs(FsError::Write {
-                    path: file.to_path_buf(),
-                    error,
-                })
+            .map_err(|error| FsError::Write {
+                path: file.to_path_buf(),
+                error,
             })?;
 
         Ok(())

--- a/crates/archive/src/zip.rs
+++ b/crates/archive/src/zip.rs
@@ -53,9 +53,9 @@ pub struct ZipPacker {
 }
 
 impl ZipPacker {
-    pub fn new(archive_file: &Path) -> miette::Result<Self> {
+    pub fn new(output_file: &Path) -> miette::Result<Self> {
         Ok(ZipPacker {
-            archive: ZipWriter::new(fs::create_file(archive_file)?),
+            archive: ZipWriter::new(fs::create_file(output_file)?),
         })
     }
 }
@@ -132,11 +132,11 @@ pub struct ZipUnpacker {
 }
 
 impl ZipUnpacker {
-    pub fn new(output_dir: &Path, archive_file: &Path) -> miette::Result<Self> {
+    pub fn new(output_dir: &Path, input_file: &Path) -> miette::Result<Self> {
         fs::create_dir_all(output_dir)?;
 
         Ok(ZipUnpacker {
-            archive: ZipArchive::new(fs::open_file(archive_file)?)
+            archive: ZipArchive::new(fs::open_file(input_file)?)
                 .map_err(|error| ZipError::UnpackFailure { error })?,
             output_dir: output_dir.to_path_buf(),
         })

--- a/crates/archive/tests/archive_test.rs
+++ b/crates/archive/tests/archive_test.rs
@@ -15,7 +15,7 @@ fn can_add_files() {
         sandbox.path().join("folder/nested.json"),
         Some("folder/nested-renamed.json"),
     );
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -39,7 +39,7 @@ fn can_add_files_with_prefix() {
     archiver.set_prefix("prefix");
     archiver.add_source_file("file.txt", None);
     archiver.add_source_file("data.json", Some("data-renamed.json"));
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -61,7 +61,7 @@ fn can_add_files_with_prefix_and_remove_when_unpacking() {
     archiver.set_prefix("prefix");
     archiver.add_source_file("file.txt", None);
     archiver.add_source_file("data.json", Some("data-renamed.json"));
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -80,7 +80,7 @@ fn can_add_globs() {
 
     let mut archiver = Archiver::new(sandbox.path(), &tarball);
     archiver.add_source_glob("**/*.json", None);
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -101,7 +101,7 @@ fn can_add_globs_with_group() {
 
     let mut archiver = Archiver::new(sandbox.path(), &tarball);
     archiver.add_source_glob("**/*.json", Some("group"));
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -123,7 +123,7 @@ fn can_add_globs_with_group_and_prefix() {
     let mut archiver = Archiver::new(sandbox.path(), &tarball);
     archiver.set_prefix("prefix");
     archiver.add_source_glob("**/*.json", Some("group"));
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -149,7 +149,7 @@ fn can_add_globs_with_prefix_and_remove_when_unpacking() {
     let mut archiver = Archiver::new(sandbox.path(), &tarball);
     archiver.set_prefix("prefix");
     archiver.add_source_glob("**/*.json", None);
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 
@@ -171,7 +171,7 @@ fn can_add_globs_with_group_and_prefix_and_remove_when_unpacking() {
     let mut archiver = Archiver::new(sandbox.path(), &tarball);
     archiver.set_prefix("prefix");
     archiver.add_source_glob("**/*.json", Some("group"));
-    archiver.pack(|_, o| ZipPacker::new(o)).unwrap();
+    archiver.pack(ZipPacker::new).unwrap();
 
     let out = create_empty_sandbox();
 

--- a/crates/archive/tests/tar_test.rs
+++ b/crates/archive/tests/tar_test.rs
@@ -8,19 +8,11 @@ use std::path::Path;
 mod tar_gz {
     use super::*;
 
-    generate_tests!(
-        "out.tar.gz",
-        |_, file| TarPacker::<flate2::write::GzEncoder<std::fs::File>>::new_gz(file, None),
-        TarUnpacker::<flate2::read::GzDecoder<std::fs::File>>::new_gz
-    );
+    generate_tests!("out.tar.gz", TarPacker::new_gz, TarUnpacker::new_gz);
 }
 
 mod tar_xz {
     use super::*;
 
-    generate_tests!(
-        "out.tar.xz",
-        |_, file| TarPacker::<xz2::write::XzEncoder<std::fs::File>>::new_xz(file, None),
-        TarUnpacker::<xz2::read::XzDecoder<std::fs::File>>::new_xz
-    );
+    generate_tests!("out.tar.xz", TarPacker::new_xz, TarUnpacker::new_xz);
 }

--- a/crates/archive/tests/zip_test.rs
+++ b/crates/archive/tests/zip_test.rs
@@ -8,5 +8,5 @@ use std::path::Path;
 mod zip {
     use super::*;
 
-    generate_tests!("out.zip", |_, file| ZipPacker::new(file), ZipUnpacker::new);
+    generate_tests!("out.zip", ZipPacker::new, ZipUnpacker::new);
 }


### PR DESCRIPTION
This avoids struct generics and allows for methods as closures.