### PR TITLE
breaking: Wrap nested errors in `Box`.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.79"
+version = "0.1.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507401cad91ec6a857ed5513a2073c82a9b9048762b885bb98655b306964681"
+checksum = "c6fa2087f2753a7da8cc1c0dbfcf89579dd57458e36769de5ac750b4671737ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -123,6 +123,12 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
 
 [[package]]
 name = "binstall-tar"
@@ -194,9 +200,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -472,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57b1e34e369d7f0151309821497440bd0266b86c77ccd69717c3b67e5eaeffe4"
+checksum = "21dabded2e32cd57ded879041205c60a4a4c4bab47bd0fd2fa8b01f30849f02b"
 dependencies = [
  "rustix",
  "windows-sys 0.52.0",
@@ -1160,18 +1166,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "3d1597b0c024618f09a9c3b8655b7e430397a36d23fdafec26d6965e9eec3eba"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -1248,11 +1254,11 @@ checksum = "e898588f33fdd5b9420719948f9f2a32c922a246964576f71ba7f24f80610fbc"
 
 [[package]]
 name = "reqwest"
-version = "0.12.2"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
 dependencies = [
- "base64",
+ "base64 0.22.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -1271,7 +1277,7 @@ dependencies = [
  "pin-project-lite",
  "rustls",
  "rustls-native-certs",
- "rustls-pemfile 1.0.4",
+ "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1348,19 +1354,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fb85efa936c42c6d5fc28d2629bb51e4b2f4b8a5211e297d599cc5a093792"
 dependencies = [
  "openssl-probe",
- "rustls-pemfile 2.1.1",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schannel",
  "security-framework",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64",
 ]
 
 [[package]]
@@ -1369,7 +1366,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f48172685e6ff52a556baa527774f61fcaa884f59daf3375c62a3f1cd2549dab"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "rustls-pki-types",
 ]
 
@@ -1445,18 +1442,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.198"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1465,9 +1462,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "3e17db7126d17feb94eb3fad46bf1a96b034e8aacbc2e775fe81505f8b0b2813"
 dependencies = [
  "itoa",
  "ryu",
@@ -1718,9 +1715,9 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.55"
+version = "2.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "002a1b3dbf967edfafc32655d0f377ab0bb7b994aa1d32c8cc7e9b8bf3ebb8f0"
+checksum = "909518bc7b1c9b779f1bbf07f2929d35af9f0f37e47c6e9ef7f9dddc1e1821f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1821,18 +1818,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
+checksum = "f0126ad08bff79f29fc3ae6a55cc72352056dfff61e3ff8bb7129476d44b23aa"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
+checksum = "d1cd413b5d558b4c5bf3680e324a6fa5014e7b7c067a51e69dbdf47eb7148b66"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2470,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ resolver = "2"
 members = ["crates/*"]
 
 [workspace.dependencies]
-async-trait = "0.1.79"
+async-trait = "0.1.80"
 dirs = "5.0.1"
 miette = "7.2.0"
 once_cell = "1.19.0"
 regex = { version = "1.10.4", default-features = false }
 relative-path = "1.9.2"
-reqwest = { version = "0.12.2", default-features = false }
+reqwest = { version = "0.12.4", default-features = false }
 rustc-hash = "1.1.0"
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.115"
+serde = { version = "1.0.198", features = ["derive"] }
+serde_json = "1.0.116"
 serde_yaml = "0.9.34"
-thiserror = "1.0.58"
+thiserror = "1.0.59"
 tokio = { version = "1.37.0", default-features = false, features = [
 	"io-util",
 	"rt",

--- a/crates/archive/src/archive_error.rs
+++ b/crates/archive/src/archive_error.rs
@@ -2,9 +2,10 @@ use starbase_styles::{Style, Stylize};
 use std::path::PathBuf;
 use thiserror::Error;
 
-#[cfg(not(feature = "miette"))]
 #[derive(Error, Debug)]
+#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum ArchiveError {
+    #[cfg_attr(feature = "miette", diagnostic(code(archive::feature_required)))]
     #[error(
         "Unable to handle archive {}. This format requires the {} feature to be enabled.",
         .path.style(Style::Path),
@@ -12,6 +13,7 @@ pub enum ArchiveError {
     )]
     FeatureNotEnabled { feature: String, path: PathBuf },
 
+    #[cfg_attr(feature = "miette", diagnostic(code(archive::unsupported_format)))]
     #[error(
         "Unable to handle archive {}, unsupported format {}.",
         .path.style(Style::Path),
@@ -19,33 +21,7 @@ pub enum ArchiveError {
     )]
     UnsupportedFormat { format: String, path: PathBuf },
 
-    #[error(
-        "Unable to handle archive {}, could not determine format.",
-        .path.style(Style::Path),
-    )]
-    UnknownFormat { path: PathBuf },
-}
-
-#[cfg(feature = "miette")]
-#[derive(Error, Debug, miette::Diagnostic)]
-pub enum ArchiveError {
-    #[diagnostic(code(archive::feature_required))]
-    #[error(
-        "Unable to handle archive {}. This format requires the {} feature to be enabled.",
-        .path.style(Style::Path),
-        .feature.style(Style::Symbol),
-    )]
-    FeatureNotEnabled { feature: String, path: PathBuf },
-
-    #[diagnostic(code(archive::unsupported_format))]
-    #[error(
-        "Unable to handle archive {}, unsupported format {}.",
-        .path.style(Style::Path),
-        .format.style(Style::Symbol),
-    )]
-    UnsupportedFormat { format: String, path: PathBuf },
-
-    #[diagnostic(code(archive::unknown_format))]
+    #[cfg_attr(feature = "miette", diagnostic(code(archive::unknown_format)))]
     #[error(
         "Unable to handle archive {}, could not determine format.",
         .path.style(Style::Path),

--- a/crates/archive/src/gz.rs
+++ b/crates/archive/src/gz.rs
@@ -44,7 +44,7 @@ impl ArchivePacker for GzPacker {
             .write_all(&fs::read_file_bytes(file)?)
             .map_err(|error| GzError::AddFailure {
                 source: file.to_path_buf(),
-                error,
+                error: Box::new(error),
             })?;
 
         self.file_count += 1;
@@ -63,7 +63,9 @@ impl ArchivePacker for GzPacker {
             .take()
             .unwrap()
             .finish()
-            .map_err(|error| GzError::PackFailure { error })?;
+            .map_err(|error| GzError::PackFailure {
+                error: Box::new(error),
+            })?;
 
         Ok(())
     }
@@ -97,7 +99,9 @@ impl ArchiveUnpacker for GzUnpacker {
 
         self.archive
             .read_to_end(&mut bytes)
-            .map_err(|error| GzError::UnpackFailure { error })?;
+            .map_err(|error| GzError::UnpackFailure {
+                error: Box::new(error),
+            })?;
 
         let out_file = self.output_dir.join(&self.file_name);
 

--- a/crates/archive/src/gz_error.rs
+++ b/crates/archive/src/gz_error.rs
@@ -9,14 +9,14 @@ pub enum GzError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to extract {} from archive.\n{error}", .source.style(Style::Path))]
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Directories cannot be gzipped. Use {} instead.", "tar".style(Style::Symbol),)]
@@ -28,13 +28,13 @@ pub enum GzError {
     #[error("Failed to pack archive.\n{error}")]
     PackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to unpack archive.\n{error}")]
     UnpackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }
 
@@ -46,7 +46,7 @@ pub enum GzError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(gz::unpack::extract))]
@@ -54,7 +54,7 @@ pub enum GzError {
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(gz::pack::no_dirs))]
@@ -69,13 +69,13 @@ pub enum GzError {
     #[error("Failed to pack archive.")]
     PackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(gz::unpack::finish))]
     #[error("Failed to unpack archive.")]
     UnpackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }

--- a/crates/archive/src/tar.rs
+++ b/crates/archive/src/tar.rs
@@ -89,7 +89,7 @@ impl ArchivePacker for TarPacker {
             .append_file(name, &mut fs::open_file(file)?)
             .map_err(|error| TarError::AddFailure {
                 source: file.to_path_buf(),
-                error,
+                error: Box::new(error),
             })?;
 
         Ok(())
@@ -102,7 +102,7 @@ impl ArchivePacker for TarPacker {
             .append_dir_all(name, dir)
             .map_err(|error| TarError::AddFailure {
                 source: dir.to_path_buf(),
-                error,
+                error: Box::new(error),
             })?;
 
         Ok(())
@@ -113,7 +113,9 @@ impl ArchivePacker for TarPacker {
 
         self.archive
             .finish()
-            .map_err(|error| TarError::PackFailure { error })?;
+            .map_err(|error| TarError::PackFailure {
+                error: Box::new(error),
+            })?;
 
         Ok(())
     }
@@ -189,9 +191,13 @@ impl ArchiveUnpacker for TarUnpacker {
         for entry in self
             .archive
             .entries()
-            .map_err(|error| TarError::UnpackFailure { error })?
+            .map_err(|error| TarError::UnpackFailure {
+                error: Box::new(error),
+            })?
         {
-            let mut entry = entry.map_err(|error| TarError::UnpackFailure { error })?;
+            let mut entry = entry.map_err(|error| TarError::UnpackFailure {
+                error: Box::new(error),
+            })?;
             let mut path: PathBuf = entry.path().unwrap().into_owned();
 
             // Remove the prefix
@@ -214,7 +220,7 @@ impl ArchiveUnpacker for TarUnpacker {
                 .unpack(&output_path)
                 .map_err(|error| TarError::ExtractFailure {
                     source: output_path.clone(),
-                    error,
+                    error: Box::new(error),
                 })?;
             // }
 

--- a/crates/archive/src/tar_error.rs
+++ b/crates/archive/src/tar_error.rs
@@ -9,26 +9,26 @@ pub enum TarError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to extract {} from archive.\n{error}", .source.style(Style::Path))]
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to pack archive.\n{error}")]
     PackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to unpack archive.\n{error}")]
     UnpackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }
 
@@ -40,7 +40,7 @@ pub enum TarError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(tar::unpack::extract))]
@@ -48,20 +48,20 @@ pub enum TarError {
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(tar::pack))]
     #[error("Failed to pack archive.")]
     PackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(tar::unpack))]
     #[error("Failed to unpack archive.")]
     UnpackFailure {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }

--- a/crates/archive/src/zip_error.rs
+++ b/crates/archive/src/zip_error.rs
@@ -10,26 +10,26 @@ pub enum ZipError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 
     #[error("Failed to extract {} from archive.\n{error}", .source.style(Style::Path))]
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to pack archive.\n{error}")]
     PackFailure {
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 
     #[error("Failed to unpack archive.\n{error}")]
     UnpackFailure {
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 }
 
@@ -41,7 +41,7 @@ pub enum ZipError {
     AddFailure {
         source: PathBuf,
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 
     #[diagnostic(code(zip::unpack::extract))]
@@ -49,20 +49,20 @@ pub enum ZipError {
     ExtractFailure {
         source: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(zip::pack::finish))]
     #[error("Failed to pack archive.")]
     PackFailure {
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 
     #[diagnostic(code(zip::unpack::finish))]
     #[error("Failed to unpack archive.")]
     UnpackFailure {
         #[source]
-        error: BaseZipError,
+        error: Box<BaseZipError>,
     },
 }

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -17,7 +17,7 @@ starbase_styles = { version = "0.3.2", path = "../styles", features = [
 	"theme",
 ] }
 async-trait = { workspace = true }
-chrono = { version = "0.4.37", default-features = false, features = [
+chrono = { version = "0.4.38", default-features = false, features = [
 	"clock",
 	"std",
 ] }

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -11,9 +11,9 @@ proc-macro = true
 
 [dependencies]
 darling = "0.20.8"
-proc-macro2 = "1.0.79"
-quote = "1.0.35"
-syn = { version = "2.0.55", features = ["full"] }
+proc-macro2 = "1.0.81"
+quote = "1.0.36"
+syn = { version = "2.0.60", features = ["full"] }
 
 [features]
 tracing = []

--- a/crates/utils/Cargo.toml
+++ b/crates/utils/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { workspace = true }
 ec4rs = { version = "1.1.0", optional = true }
 
 # fs
-fs4 = { version = "0.8.1", optional = true }
+fs4 = { version = "0.8.2", optional = true }
 
 # glob
 wax = { version = "0.6.0", optional = true, features = ["walk"] }

--- a/crates/utils/src/fs.rs
+++ b/crates/utils/src/fs.rs
@@ -28,13 +28,13 @@ pub fn append_file<T: AsRef<Path>, D: AsRef<[u8]>>(path: T, data: D) -> Result<(
         .open(path)
         .map_err(|error| FsError::Write {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
 
     file.write_all(data.as_ref())
         .map_err(|error| FsError::Write {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
 
     Ok(())
@@ -56,7 +56,7 @@ pub fn copy_file<S: AsRef<Path>, D: AsRef<Path>>(from: S, to: D) -> Result<(), F
     fs::copy(from, to).map_err(|error| FsError::Copy {
         from: from.to_path_buf(),
         to: to.to_path_buf(),
-        error,
+        error: Box::new(error),
     })?;
 
     Ok(())
@@ -110,7 +110,7 @@ pub fn create_file<T: AsRef<Path>>(path: T) -> Result<File, FsError> {
 
     File::create(path).map_err(|error| FsError::Create {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -133,7 +133,7 @@ pub fn create_file_if_missing<T: AsRef<Path>>(path: T) -> Result<File, FsError> 
         .open(path)
         .map_err(|error| FsError::Create {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })
 }
 
@@ -152,7 +152,7 @@ pub fn create_dir_all<T: AsRef<Path>>(path: T) -> Result<(), FsError> {
 
         fs::create_dir_all(path).map_err(|error| FsError::Create {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
     }
 
@@ -304,7 +304,7 @@ pub fn metadata<T: AsRef<Path>>(path: T) -> Result<fs::Metadata, FsError> {
 
     fs::metadata(path).map_err(|error| FsError::Read {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -318,7 +318,7 @@ pub fn open_file<T: AsRef<Path>>(path: T) -> Result<File, FsError> {
 
     File::open(path).map_err(|error| FsError::Read {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -337,7 +337,7 @@ pub fn read_dir<T: AsRef<Path>>(path: T) -> Result<Vec<fs::DirEntry>, FsError> {
 
     let entries = fs::read_dir(path).map_err(|error| FsError::Read {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })?;
 
     for entry in entries {
@@ -348,7 +348,7 @@ pub fn read_dir<T: AsRef<Path>>(path: T) -> Result<Vec<fs::DirEntry>, FsError> {
             Err(error) => {
                 return Err(FsError::Read {
                     path: path.to_path_buf(),
-                    error,
+                    error: Box::new(error),
                 });
             }
         }
@@ -385,7 +385,7 @@ pub fn read_file<T: AsRef<Path>>(path: T) -> Result<String, FsError> {
 
     fs::read_to_string(path).map_err(|error| FsError::Read {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -398,7 +398,7 @@ pub fn read_file_bytes<T: AsRef<Path>>(path: T) -> Result<Vec<u8>, FsError> {
 
     fs::read(path).map_err(|error| FsError::Read {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -437,7 +437,7 @@ pub fn remove_link<T: AsRef<Path>>(path: T) -> Result<(), FsError> {
 
             fs::remove_file(path).map_err(|error| FsError::Remove {
                 path: path.to_path_buf(),
-                error,
+                error: Box::new(error),
             })?;
         }
     }
@@ -455,7 +455,7 @@ pub fn remove_file<T: AsRef<Path>>(path: T) -> Result<(), FsError> {
 
         fs::remove_file(path).map_err(|error| FsError::Remove {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
     }
 
@@ -486,7 +486,7 @@ pub fn remove_file_if_older_than<T: AsRef<Path>>(
 
                 fs::remove_file(path).map_err(|error| FsError::Remove {
                     path: path.to_path_buf(),
-                    error,
+                    error: Box::new(error),
                 })?;
 
                 return Ok(meta.len());
@@ -522,7 +522,7 @@ pub fn remove_file_if_stale<T: AsRef<Path>>(
 
                 fs::remove_file(path).map_err(|error| FsError::Remove {
                     path: path.to_path_buf(),
-                    error,
+                    error: Box::new(error),
                 })?;
 
                 return Ok(meta.len());
@@ -544,7 +544,7 @@ pub fn remove_dir_all<T: AsRef<Path>>(path: T) -> Result<(), FsError> {
 
         fs::remove_dir_all(path).map_err(|error| FsError::Remove {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
     }
 
@@ -606,7 +606,7 @@ pub fn rename<F: AsRef<Path>, T: AsRef<Path>>(from: F, to: T) -> Result<(), FsEr
     fs::rename(from, to).map_err(|error| FsError::Rename {
         from: from.to_path_buf(),
         to: to.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -625,7 +625,7 @@ pub fn update_perms<T: AsRef<Path>>(path: T, mode: Option<u32>) -> Result<(), Fs
     fs::set_permissions(path, fs::Permissions::from_mode(mode)).map_err(|error| {
         FsError::Perms {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         }
     })?;
 
@@ -653,7 +653,7 @@ pub fn write_file<T: AsRef<Path>, D: AsRef<[u8]>>(path: T, data: D) -> Result<()
 
     fs::write(path, data).map_err(|error| FsError::Write {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -679,6 +679,6 @@ pub fn write_file_with_config<T: AsRef<Path>, D: AsRef<[u8]>>(
 
     fs::write(path, data).map_err(|error| FsError::Write {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }

--- a/crates/utils/src/fs_error.rs
+++ b/crates/utils/src/fs_error.rs
@@ -10,42 +10,42 @@ pub enum FsError {
         from: PathBuf,
         to: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to create {}.\n{error}", .path.style(Style::Path))]
     Create {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to lock {}.\n{error}", .path.style(Style::Path))]
     Lock {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to update permissions for {}.\n{error}", .path.style(Style::Path))]
     Perms {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to read path {}.\n{error}", .path.style(Style::Path))]
     Read {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to remove path {}.\n{error}", .path.style(Style::Path))]
     Remove {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("A directory is required for path {}.", .path.style(Style::Path))]
@@ -56,21 +56,21 @@ pub enum FsError {
         from: PathBuf,
         to: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to unlock {}.\n{error}", .path.style(Style::Path))]
     Unlock {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[error("Failed to write {}.\n{error}", .path.style(Style::Path))]
     Write {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }
 
@@ -83,7 +83,7 @@ pub enum FsError {
         from: PathBuf,
         to: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::create))]
@@ -91,7 +91,7 @@ pub enum FsError {
     Create {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::lock))]
@@ -99,7 +99,7 @@ pub enum FsError {
     Lock {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::perms))]
@@ -107,7 +107,7 @@ pub enum FsError {
     Perms {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::read))]
@@ -115,7 +115,7 @@ pub enum FsError {
     Read {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::remove))]
@@ -123,7 +123,7 @@ pub enum FsError {
     Remove {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::require_dir))]
@@ -136,7 +136,7 @@ pub enum FsError {
         from: PathBuf,
         to: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::unlock))]
@@ -144,7 +144,7 @@ pub enum FsError {
     Unlock {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
     #[diagnostic(code(fs::write), help("Does the parent directory exist?"))]
@@ -152,6 +152,6 @@ pub enum FsError {
     Write {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 }

--- a/crates/utils/src/json.rs
+++ b/crates/utils/src/json.rs
@@ -50,9 +50,13 @@ where
 {
     trace!("Parsing JSON");
 
-    let contents = clean(data.as_ref()).map_err(|error| JsonError::Clean { error })?;
+    let contents = clean(data.as_ref()).map_err(|error| JsonError::Clean {
+        error: Box::new(error),
+    })?;
 
-    serde_json::from_str(&contents).map_err(|error| JsonError::Parse { error })
+    serde_json::from_str(&contents).map_err(|error| JsonError::Parse {
+        error: Box::new(error),
+    })
 }
 
 /// Format and serialize the provided value into a string.
@@ -64,9 +68,13 @@ where
     trace!("Formatting JSON");
 
     if pretty {
-        serde_json::to_string_pretty(&data).map_err(|error| JsonError::Format { error })
+        serde_json::to_string_pretty(&data).map_err(|error| JsonError::Format {
+            error: Box::new(error),
+        })
     } else {
-        serde_json::to_string(&data).map_err(|error| JsonError::Format { error })
+        serde_json::to_string(&data).map_err(|error| JsonError::Format {
+            error: Box::new(error),
+        })
     }
 }
 
@@ -81,14 +89,14 @@ where
     let path = path.as_ref();
     let contents = clean(fs::read_file(path)?).map_err(|error| JsonError::CleanFile {
         path: path.to_owned(),
-        error,
+        error: Box::new(error),
     })?;
 
     trace!(file = ?path, "Reading JSON file");
 
     serde_json::from_str(&contents).map_err(|error| JsonError::ReadFile {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -109,12 +117,12 @@ where
     let data = if pretty {
         serde_json::to_string_pretty(&json).map_err(|error| JsonError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?
     } else {
         serde_json::to_string(&json).map_err(|error| JsonError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?
     };
 
@@ -157,7 +165,7 @@ pub fn write_file_with_config<P: AsRef<Path>>(
     json.serialize(&mut serializer)
         .map_err(|error| JsonError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?;
 
     let mut data = unsafe { String::from_utf8_unchecked(writer) };

--- a/crates/utils/src/json_error.rs
+++ b/crates/utils/src/json_error.rs
@@ -101,3 +101,9 @@ pub enum JsonError {
         error: Box<serde_json::Error>,
     },
 }
+
+impl From<FsError> for JsonError {
+    fn from(e: FsError) -> JsonError {
+        JsonError::Fs(Box::new(e))
+    }
+}

--- a/crates/utils/src/json_error.rs
+++ b/crates/utils/src/json_error.rs
@@ -3,55 +3,101 @@ use starbase_styles::{Style, Stylize};
 use std::path::PathBuf;
 use thiserror::Error;
 
+#[cfg(not(feature = "miette"))]
 #[derive(Error, Debug)]
-#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum JsonError {
-    #[cfg_attr(feature = "miette", diagnostic(transparent))]
     #[error(transparent)]
-    Fs(#[from] FsError),
+    Fs(#[from] Box<FsError>),
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::clean)))]
+    #[error("Failed to clean comments and trailing commas from JSON.\n{error}")]
+    Clean {
+        #[source]
+        error: Box<std::io::Error>,
+    },
+
+    #[error("Failed to clean comments and trailing commas in JSON file {}.\n{error}", .path.style(Style::Path))]
+    CleanFile {
+        path: PathBuf,
+        #[source]
+        error: Box<std::io::Error>,
+    },
+
+    #[error("Failed to format JSON.\n{error}")]
+    Format {
+        #[source]
+        error: Box<serde_json::Error>,
+    },
+
+    #[error("Failed to parse JSON.\n{error}")]
+    Parse {
+        #[source]
+        error: Box<serde_json::Error>,
+    },
+
+    #[error("Failed to parse JSON file {}.\n{error}", .path.style(Style::Path))]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        error: Box<serde_json::Error>,
+    },
+
+    #[error("Failed to format JSON for file {}.\n{error}", .path.style(Style::Path))]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        error: Box<serde_json::Error>,
+    },
+}
+
+#[cfg(feature = "miette")]
+#[derive(Error, Debug, miette::Diagnostic)]
+pub enum JsonError {
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Fs(#[from] Box<FsError>),
+
+    #[diagnostic(code(json::clean))]
     #[error("Failed to clean comments and trailing commas from JSON.")]
     Clean {
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::clean_file)))]
+    #[diagnostic(code(json::clean_file))]
     #[error("Failed to clean comments and trailing commas in JSON file {}.", .path.style(Style::Path))]
     CleanFile {
         path: PathBuf,
         #[source]
-        error: std::io::Error,
+        error: Box<std::io::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::format)))]
+    #[diagnostic(code(json::format))]
     #[error("Failed to format JSON.")]
     Format {
         #[source]
-        error: serde_json::Error,
+        error: Box<serde_json::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::parse)))]
+    #[diagnostic(code(json::parse))]
     #[error("Failed to parse JSON.")]
     Parse {
         #[source]
-        error: serde_json::Error,
+        error: Box<serde_json::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::parse_file)))]
+    #[diagnostic(code(json::parse_file))]
     #[error("Failed to parse JSON file {}.", .path.style(Style::Path))]
     ReadFile {
         path: PathBuf,
         #[source]
-        error: serde_json::Error,
+        error: Box<serde_json::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(json::format_file)))]
+    #[diagnostic(code(json::format_file))]
     #[error("Failed to format JSON for file {}.", .path.style(Style::Path))]
     WriteFile {
         path: PathBuf,
         #[source]
-        error: serde_json::Error,
+        error: Box<serde_json::Error>,
     },
 }

--- a/crates/utils/src/net.rs
+++ b/crates/utils/src/net.rs
@@ -19,7 +19,7 @@ pub async fn download_from_url_with_client<S: AsRef<str>, D: AsRef<Path>>(
     let source_url = source_url.as_ref();
     let url = Url::parse(source_url).map_err(|error| NetError::UrlParseFailed {
         url: source_url.to_owned(),
-        error,
+        error: Box::new(error),
     })?;
 
     // Fetch the file from the HTTP source
@@ -28,7 +28,7 @@ pub async fn download_from_url_with_client<S: AsRef<str>, D: AsRef<Path>>(
         .send()
         .await
         .map_err(|error| NetError::Http {
-            error,
+            error: Box::new(error),
             url: source_url.to_owned(),
         })?;
 
@@ -51,7 +51,7 @@ pub async fn download_from_url_with_client<S: AsRef<str>, D: AsRef<Path>>(
     fs::write_file(
         dest_file,
         response.bytes().await.map_err(|error| NetError::Http {
-            error,
+            error: Box::new(error),
             url: source_url.to_owned(),
         })?,
     )?;

--- a/crates/utils/src/net_error.rs
+++ b/crates/utils/src/net_error.rs
@@ -66,3 +66,9 @@ pub enum NetError {
         error: Box<url::ParseError>,
     },
 }
+
+impl From<FsError> for NetError {
+    fn from(e: FsError) -> NetError {
+        NetError::Fs(Box::new(e))
+    }
+}

--- a/crates/utils/src/net_error.rs
+++ b/crates/utils/src/net_error.rs
@@ -2,39 +2,67 @@ use crate::fs::FsError;
 use starbase_styles::{Style, Stylize};
 use thiserror::Error;
 
+#[cfg(not(feature = "miette"))]
 #[derive(Error, Debug)]
-#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum NetError {
-    #[cfg_attr(feature = "miette", diagnostic(transparent))]
     #[error(transparent)]
-    Fs(#[from] FsError),
+    Fs(#[from] Box<FsError>),
 
-    #[cfg_attr(feature = "miette", diagnostic(code(net::http)))]
-    #[error("Failed to make HTTP request for {}.", .url.style(Style::Url))]
+    #[error("Failed to make HTTP request for {}.\n{error}", .url.style(Style::Url))]
     Http {
         url: String,
-
         #[source]
-        error: reqwest::Error,
+        error: Box<reqwest::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(net::download_failed)))]
     #[error(
         "Failed to download file from {} ({status}).",
         .url.style(Style::Url),
     )]
     DownloadFailed { url: String, status: String },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(net::not_found)))]
     #[error("Unable to download file, the URL {} does not exist.", .url.style(Style::Url))]
     UrlNotFound { url: String },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(net::invalid_url)))]
+    #[error("Failed to parse URL {}.\n{error}", .url.style(Style::Url))]
+    UrlParseFailed {
+        url: String,
+        #[source]
+        error: Box<url::ParseError>,
+    },
+}
+
+#[cfg(feature = "miette")]
+#[derive(Error, Debug, miette::Diagnostic)]
+pub enum NetError {
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Fs(#[from] Box<FsError>),
+
+    #[diagnostic(code(net::http))]
+    #[error("Failed to make HTTP request for {}.", .url.style(Style::Url))]
+    Http {
+        url: String,
+        #[source]
+        error: Box<reqwest::Error>,
+    },
+
+    #[diagnostic(code(net::download_failed))]
+    #[error(
+        "Failed to download file from {} ({status}).",
+        .url.style(Style::Url),
+    )]
+    DownloadFailed { url: String, status: String },
+
+    #[diagnostic(code(net::not_found))]
+    #[error("Unable to download file, the URL {} does not exist.", .url.style(Style::Url))]
+    UrlNotFound { url: String },
+
+    #[diagnostic(code(net::invalid_url))]
     #[error("Failed to parse URL {}.", .url.style(Style::Url))]
     UrlParseFailed {
         url: String,
-
         #[source]
-        error: url::ParseError,
+        error: Box<url::ParseError>,
     },
 }

--- a/crates/utils/src/toml.rs
+++ b/crates/utils/src/toml.rs
@@ -17,7 +17,9 @@ where
 {
     trace!("Parsing TOML");
 
-    toml::from_str(data.as_ref()).map_err(|error| TomlError::Parse { error })
+    toml::from_str(data.as_ref()).map_err(|error| TomlError::Parse {
+        error: Box::new(error),
+    })
 }
 
 /// Format and serialize the provided value into a string.
@@ -29,9 +31,13 @@ where
     trace!("Formatting TOML");
 
     if pretty {
-        toml::to_string_pretty(&data).map_err(|error| TomlError::Format { error })
+        toml::to_string_pretty(&data).map_err(|error| TomlError::Format {
+            error: Box::new(error),
+        })
     } else {
-        toml::to_string(&data).map_err(|error| TomlError::Format { error })
+        toml::to_string(&data).map_err(|error| TomlError::Format {
+            error: Box::new(error),
+        })
     }
 }
 
@@ -50,7 +56,7 @@ where
 
     toml::from_str(&contents).map_err(|error| TomlError::ReadFile {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -69,12 +75,12 @@ where
     let data = if pretty {
         toml::to_string_pretty(&toml).map_err(|error| TomlError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?
     } else {
         toml::to_string(&toml).map_err(|error| TomlError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?
     };
 

--- a/crates/utils/src/toml_error.rs
+++ b/crates/utils/src/toml_error.rs
@@ -3,40 +3,73 @@ use starbase_styles::{Style, Stylize};
 use std::path::PathBuf;
 use thiserror::Error;
 
+#[cfg(not(feature = "miette"))]
 #[derive(Error, Debug)]
-#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum TomlError {
-    #[cfg_attr(feature = "miette", diagnostic(transparent))]
     #[error(transparent)]
-    Fs(#[from] FsError),
+    Fs(#[from] Box<FsError>),
 
-    #[cfg_attr(feature = "miette", diagnostic(code(toml::format)))]
+    #[error("Failed to format TOML.\n{error}")]
+    Format {
+        #[source]
+        error: Box<toml::ser::Error>,
+    },
+
+    #[error("Failed to parse TOML.\n{error}")]
+    Parse {
+        #[source]
+        error: Box<toml::de::Error>,
+    },
+
+    #[error("Failed to parse TOML file {}.\n{error}", .path.style(Style::Path))]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        error: Box<toml::de::Error>,
+    },
+
+    #[error("Failed to format TOML for file {}.\n{error}", .path.style(Style::Path))]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        error: Box<toml::ser::Error>,
+    },
+}
+
+#[cfg(feature = "miette")]
+#[derive(Error, Debug, miette::Diagnostic)]
+pub enum TomlError {
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Fs(#[from] Box<FsError>),
+
+    #[diagnostic(code(toml::format))]
     #[error("Failed to format TOML.")]
     Format {
         #[source]
-        error: toml::ser::Error,
+        error: Box<toml::ser::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(toml::parse)))]
+    #[diagnostic(code(toml::parse))]
     #[error("Failed to parse TOML.")]
     Parse {
         #[source]
-        error: toml::de::Error,
+        error: Box<toml::de::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(toml::parse_file)))]
+    #[diagnostic(code(toml::parse_file))]
     #[error("Failed to parse TOML file {}.", .path.style(Style::Path))]
     ReadFile {
         path: PathBuf,
         #[source]
-        error: toml::de::Error,
+        error: Box<toml::de::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(toml::format_file)))]
+    #[diagnostic(code(toml::format_file))]
     #[error("Failed to format TOML for file {}.", .path.style(Style::Path))]
     WriteFile {
         path: PathBuf,
         #[source]
-        error: toml::ser::Error,
+        error: Box<toml::ser::Error>,
     },
 }

--- a/crates/utils/src/toml_error.rs
+++ b/crates/utils/src/toml_error.rs
@@ -73,3 +73,9 @@ pub enum TomlError {
         error: Box<toml::ser::Error>,
     },
 }
+
+impl From<FsError> for TomlError {
+    fn from(e: FsError) -> TomlError {
+        TomlError::Fs(Box::new(e))
+    }
+}

--- a/crates/utils/src/yaml.rs
+++ b/crates/utils/src/yaml.rs
@@ -44,7 +44,9 @@ where
 {
     trace!("Parsing YAML");
 
-    serde_yaml::from_str(data.as_ref()).map_err(|error| YamlError::Parse { error })
+    serde_yaml::from_str(data.as_ref()).map_err(|error| YamlError::Parse {
+        error: Box::new(error),
+    })
 }
 
 /// Format and serialize the provided value into a string.
@@ -55,7 +57,9 @@ where
 {
     trace!("Formatting YAML");
 
-    serde_yaml::to_string(&data).map_err(|error| YamlError::Format { error })
+    serde_yaml::to_string(&data).map_err(|error| YamlError::Format {
+        error: Box::new(error),
+    })
 }
 
 /// Read a file at the provided path and deserialize into the required type.
@@ -73,7 +77,7 @@ where
 
     serde_yaml::from_str(&contents).map_err(|error| YamlError::ReadFile {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })
 }
 
@@ -93,7 +97,7 @@ where
 
     let data = serde_yaml::to_string(&yaml).map_err(|error| YamlError::WriteFile {
         path: path.to_path_buf(),
-        error,
+        error: Box::new(error),
     })?;
 
     fs::write_file(path, data)?;
@@ -121,7 +125,7 @@ where
     let mut data = serde_yaml::to_string(&yaml)
         .map_err(|error| YamlError::WriteFile {
             path: path.to_path_buf(),
-            error,
+            error: Box::new(error),
         })?
         .trim()
         .to_string();

--- a/crates/utils/src/yaml_error.rs
+++ b/crates/utils/src/yaml_error.rs
@@ -3,40 +3,73 @@ use starbase_styles::{Style, Stylize};
 use std::path::PathBuf;
 use thiserror::Error;
 
+#[cfg(not(feature = "miette"))]
 #[derive(Error, Debug)]
-#[cfg_attr(feature = "miette", derive(miette::Diagnostic))]
 pub enum YamlError {
-    #[cfg_attr(feature = "miette", diagnostic(transparent))]
     #[error(transparent)]
-    Fs(#[from] FsError),
+    Fs(#[from] Box<FsError>),
 
-    #[cfg_attr(feature = "miette", diagnostic(code(yaml::format)))]
+    #[error("Failed to format YAML.\n{error}")]
+    Format {
+        #[source]
+        error: Box<serde_yaml::Error>,
+    },
+
+    #[error("Failed to parse YAML.\n{error}")]
+    Parse {
+        #[source]
+        error: Box<serde_yaml::Error>,
+    },
+
+    #[error("Failed to parse YAML file {}.\n{error}", .path.style(Style::Path))]
+    ReadFile {
+        path: PathBuf,
+        #[source]
+        error: Box<serde_yaml::Error>,
+    },
+
+    #[error("Failed to format YAML for file {}.\n{error}", .path.style(Style::Path))]
+    WriteFile {
+        path: PathBuf,
+        #[source]
+        error: Box<serde_yaml::Error>,
+    },
+}
+
+#[cfg(feature = "miette")]
+#[derive(Error, Debug, miette::Diagnostic)]
+pub enum YamlError {
+    #[diagnostic(transparent)]
+    #[error(transparent)]
+    Fs(#[from] Box<FsError>),
+
+    #[diagnostic(code(yaml::format))]
     #[error("Failed to format YAML.")]
     Format {
         #[source]
-        error: serde_yaml::Error,
+        error: Box<serde_yaml::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(yaml::parse)))]
+    #[diagnostic(code(yaml::parse))]
     #[error("Failed to parse YAML.")]
     Parse {
         #[source]
-        error: serde_yaml::Error,
+        error: Box<serde_yaml::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(yaml::parse_file)))]
+    #[diagnostic(code(yaml::parse_file))]
     #[error("Failed to parse YAML file {}.", .path.style(Style::Path))]
     ReadFile {
         path: PathBuf,
         #[source]
-        error: serde_yaml::Error,
+        error: Box<serde_yaml::Error>,
     },
 
-    #[cfg_attr(feature = "miette", diagnostic(code(yaml::format_file)))]
+    #[diagnostic(code(yaml::format_file))]
     #[error("Failed to format YAML for file {}.", .path.style(Style::Path))]
     WriteFile {
         path: PathBuf,
         #[source]
-        error: serde_yaml::Error,
+        error: Box<serde_yaml::Error>,
     },
 }

--- a/crates/utils/src/yaml_error.rs
+++ b/crates/utils/src/yaml_error.rs
@@ -73,3 +73,9 @@ pub enum YamlError {
         error: Box<serde_yaml::Error>,
     },
 }
+
+impl From<FsError> for YamlError {
+    fn from(e: FsError) -> YamlError {
+        YamlError::Fs(Box::new(e))
+    }
+}


### PR DESCRIPTION
This greatly reduces the size of these enums, almost by half.