### PR TITLE
breaking: Migrate to `scc` for managing instances.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,9 +266,9 @@ checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
 dependencies = [
  "cfg-if",
 ]
@@ -444,9 +444,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.28"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1442,18 +1442,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1403,6 +1403,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec96560eea317a9cc4e0bb1f6a2c93c09a19b8c4fc5cb3fcc0ec1c094cd783e2"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1425,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84345e4c9bd703274a082fb80caaa99b7612be48dfaa1dd9266577ec412309d"
 
 [[package]]
 name = "security-framework"
@@ -1566,6 +1581,7 @@ dependencies = [
  "miette 7.2.0",
  "num_cpus",
  "rustc-hash",
+ "scc",
  "starbase_events",
  "starbase_macros",
  "starbase_styles",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,8 @@ regex = { version = "1.10.4", default-features = false }
 relative-path = "1.9.2"
 reqwest = { version = "0.12.4", default-features = false }
 rustc-hash = "1.1.0"
-serde = { version = "1.0.198", features = ["derive"] }
+scc = "2.1.0"
+serde = { version = "1.0.199", features = ["derive"] }
 serde_json = "1.0.116"
 serde_yaml = "0.9.34"
 thiserror = "1.0.59"

--- a/crates/archive/Cargo.toml
+++ b/crates/archive/Cargo.toml
@@ -19,7 +19,7 @@ rustc-hash = { workspace = true }
 tracing = { workspace = true }
 thiserror = { workspace = true }
 
-flate2 = { version = "1.0.28", optional = true }
+flate2 = { version = "1.0.30", optional = true }
 
 # tar
 # https://github.com/moonrepo/starbase/issues/56

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -24,6 +24,7 @@ chrono = { version = "0.4.38", default-features = false, features = [
 miette = { workspace = true, features = ["fancy"] }
 num_cpus = "1.16.0"
 rustc-hash = { workspace = true }
+scc = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["tracing"] }
 tracing = { workspace = true, optional = true }

--- a/crates/framework/src/app.rs
+++ b/crates/framework/src/app.rs
@@ -32,7 +32,7 @@ pub trait AppExtension {
 #[derive(Debug)]
 pub struct App {
     // Data
-    args: ArgsMap,
+    args: Arc<ArgsMap>,
     emitters: Emitters,
     resources: Resources,
     states: States,
@@ -50,7 +50,7 @@ impl App {
     pub fn new() -> App {
         let mut app = App {
             analyzers: vec![],
-            args: ArgsMap::default(),
+            args: Arc::new(ArgsMap::default()),
             emitters: Arc::new(EmitterManager::default()),
             executors: vec![],
             shutdowns: vec![],
@@ -171,10 +171,11 @@ impl App {
     /// Start the application and run all registered systems grouped into phases.
     pub async fn run(&mut self) -> miette::Result<Arc<StateManager>> {
         let states = Arc::clone(&self.states);
-        states.set(ExecuteArgs(mem::take(&mut self.args)));
+        states.set(ExecuteArgs(Arc::clone(&self.args)));
+
+        let resources = Arc::clone(&self.resources);
 
         let emitters = Arc::clone(&self.emitters);
-        let resources = Arc::clone(&self.resources);
 
         // Startup
         if let Err(error) = self

--- a/crates/framework/src/app.rs
+++ b/crates/framework/src/app.rs
@@ -9,7 +9,7 @@ use miette::IntoDiagnostic;
 use std::any::Any;
 use std::mem;
 use std::sync::Arc;
-use tokio::sync::{RwLock, Semaphore};
+use tokio::sync::Semaphore;
 use tokio::task;
 use tracing::trace;
 
@@ -26,16 +26,16 @@ pub enum Phase {
 }
 
 pub trait AppExtension {
-    fn extend(self, app: &mut App) -> AppResult<()>;
+    fn extend(self, app: &mut App) -> AppResult;
 }
 
 #[derive(Debug)]
 pub struct App {
     // Data
     args: ArgsMap,
-    emitters: EmitterManager,
-    resources: ResourceManager,
-    states: StateManager,
+    emitters: Emitters,
+    resources: Resources,
+    states: States,
 
     // Systems
     startups: Vec<BoxedSystem>,
@@ -51,12 +51,12 @@ impl App {
         let mut app = App {
             analyzers: vec![],
             args: ArgsMap::default(),
-            emitters: EmitterManager::default(),
+            emitters: Arc::new(EmitterManager::default()),
             executors: vec![],
             shutdowns: vec![],
             startups: vec![],
-            resources: ResourceManager::default(),
-            states: StateManager::default(),
+            resources: Arc::new(ResourceManager::default()),
+            states: Arc::new(StateManager::default()),
         };
         app.startup(start_startup_phase);
         app.analyze(start_analyze_phase);
@@ -169,13 +169,12 @@ impl App {
     }
 
     /// Start the application and run all registered systems grouped into phases.
-    pub async fn run(&mut self) -> miette::Result<StateManager> {
-        let mut state_manager = mem::take(&mut self.states);
-        state_manager.set(ExecuteArgs(mem::take(&mut self.args)));
+    pub async fn run(&mut self) -> miette::Result<Arc<StateManager>> {
+        let states = Arc::clone(&self.states);
+        states.set(ExecuteArgs(mem::take(&mut self.args)));
 
-        let emitters = Arc::new(RwLock::new(mem::take(&mut self.emitters)));
-        let resources = Arc::new(RwLock::new(mem::take(&mut self.resources)));
-        let states = Arc::new(RwLock::new(state_manager));
+        let emitters = Arc::clone(&self.emitters);
+        let resources = Arc::clone(&self.resources);
 
         // Startup
         if let Err(error) = self
@@ -213,9 +212,6 @@ impl App {
         // Shutdown
         self.run_shutdown(states.clone(), resources.clone(), emitters.clone())
             .await?;
-
-        let states = Arc::into_inner(states)
-            .expect("Failed to acquire state before closing the application. This typically means that threads are still running that have not been awaited.").into_inner();
 
         Ok(states)
     }

--- a/crates/framework/src/app_state.rs
+++ b/crates/framework/src/app_state.rs
@@ -13,7 +13,7 @@ pub struct AppPhase {
 }
 
 #[system]
-pub async fn start_startup_phase(states: StatesMut) {
+pub async fn start_startup_phase(states: States) {
     states.set(AppPhase {
         phase: Phase::Startup,
     });

--- a/crates/framework/src/args.rs
+++ b/crates/framework/src/args.rs
@@ -1,19 +1,18 @@
 use crate::states::StateInstance;
-use rustc_hash::FxHashMap;
 use std::any::{Any, TypeId};
 use std::fmt::Debug;
 
 #[derive(Debug, Default)]
 pub struct ArgsMap {
-    cache: FxHashMap<TypeId, Box<dyn Any + Sync + Send>>,
+    cache: scc::HashMap<TypeId, Box<dyn Any + Sync + Send>>,
 }
 
 impl ArgsMap {
     /// Get an immutable args reference for the provided type.
     /// If the args does not exist, a [`None`] is returned.
     pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
-        if let Some(value) = self.cache.get(&TypeId::of::<T>()) {
-            return value.downcast_ref::<T>();
+        if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
+            return entry.get().downcast_ref::<T>();
         }
 
         None
@@ -21,9 +20,8 @@ impl ArgsMap {
 
     /// Set the args into the registry with the provided type.
     /// If an exact type already exists, it'll be overwritten.
-    pub fn set<T: Any + Send + Sync>(&mut self, args: T) -> &mut Self {
+    pub fn set<T: Any + Send + Sync>(&self, args: T) {
         self.cache.insert(TypeId::of::<T>(), Box::new(args));
-        self
     }
 }
 

--- a/crates/framework/src/args.rs
+++ b/crates/framework/src/args.rs
@@ -1,18 +1,22 @@
+use crate::instance::{BoxedAnyInstance, InstanceGuard};
 use crate::states::StateInstance;
 use std::any::{Any, TypeId};
 use std::fmt::Debug;
+use std::sync::Arc;
 
+// Don't use `create_instance_manager` because we have no trait for
+// values to implement! We also return `None` intstead of panicing.
 #[derive(Debug, Default)]
 pub struct ArgsMap {
-    cache: scc::HashMap<TypeId, Box<dyn Any + Sync + Send>>,
+    cache: scc::HashMap<TypeId, BoxedAnyInstance>,
 }
 
 impl ArgsMap {
-    /// Get an immutable args reference for the provided type.
+    /// Get an args reference for the provided type.
     /// If the args does not exist, a [`None`] is returned.
-    pub fn get<T: Any + Send + Sync>(&self) -> Option<&T> {
+    pub fn get<T: Any + Send + Sync>(&self) -> Option<InstanceGuard<T>> {
         if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
-            return entry.get().downcast_ref::<T>();
+            return Some(InstanceGuard::new(entry));
         }
 
         None
@@ -21,15 +25,15 @@ impl ArgsMap {
     /// Set the args into the registry with the provided type.
     /// If an exact type already exists, it'll be overwritten.
     pub fn set<T: Any + Send + Sync>(&self, args: T) {
-        self.cache.insert(TypeId::of::<T>(), Box::new(args));
+        let _ = self.cache.insert(TypeId::of::<T>(), Box::new(args));
     }
 }
 
 #[derive(Debug)]
-pub struct ExecuteArgs(pub ArgsMap);
+pub struct ExecuteArgs(pub Arc<ArgsMap>);
 
 impl StateInstance for ExecuteArgs {
-    fn extract<T: Any + Send + Sync>(&self) -> Option<&T> {
-        self.0.get::<T>()
+    fn extract<T: Any + Clone + Send + Sync>(&self) -> Option<T> {
+        self.0.get::<T>().map(|i| i.read().to_owned())
     }
 }

--- a/crates/framework/src/args.rs
+++ b/crates/framework/src/args.rs
@@ -5,7 +5,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 // Don't use `create_instance_manager` because we have no trait for
-// values to implement! We also return `None` intstead of panicing.
+// values to implement! We also return `None` instead of panicing.
 #[derive(Debug, Default)]
 pub struct ArgsMap {
     cache: scc::HashMap<TypeId, BoxedAnyInstance>,

--- a/crates/framework/src/emitters.rs
+++ b/crates/framework/src/emitters.rs
@@ -1,9 +1,7 @@
 use crate::create_instance_manager;
-use rustc_hash::FxHashMap;
 use std::any::{type_name, Any, TypeId};
 use std::fmt::Debug;
 use std::sync::Arc;
-use tokio::sync::RwLock;
 
 pub use starbase_events::{Emitter, Event, EventResult, EventState, Subscriber, SubscriberFunc};
 
@@ -27,4 +25,4 @@ impl EmitterManager {
 
 impl<E: Event + 'static> EmitterInstance for Emitter<E> {}
 
-pub type Emitters = Arc<RwLock<EmitterManager>>;
+pub type Emitters = Arc<EmitterManager>;

--- a/crates/framework/src/emitters.rs
+++ b/crates/framework/src/emitters.rs
@@ -19,7 +19,7 @@ impl EmitterManager {
     /// When complete, the provided event will be returned along with the value returned
     /// by the subscriber that returned [`EventState::Return`], or [`None`] if not occurred.
     pub async fn emit<E: Event + 'static>(&self, event: E) -> miette::Result<E::Data> {
-        self.get::<Emitter<E>>().emit(event).await
+        self.get::<Emitter<E>>().read().emit(event).await
     }
 }
 

--- a/crates/framework/src/instance.rs
+++ b/crates/framework/src/instance.rs
@@ -1,5 +1,6 @@
 use scc::hash_map::OccupiedEntry;
 use std::any::{Any, TypeId};
+use std::ops::{Deref, DerefMut};
 
 pub type BoxedAnyInstance = Box<dyn Any + Sync + Send>;
 
@@ -25,6 +26,20 @@ impl<'i, T: 'static> InstanceGuard<'i, T> {
     }
 }
 
+impl<'i, T: 'static> Deref for InstanceGuard<'i, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.read()
+    }
+}
+
+impl<'i, T: 'static> DerefMut for InstanceGuard<'i, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.write()
+    }
+}
+
 // Creates a simple `Any` map registry of objects by type.
 // These methods `panic!` because it immediately bubbles up that
 // the order of operations for application state is wrong, and
@@ -41,7 +56,7 @@ macro_rules! create_instance_manager {
 
         #[derive(Debug, Default)]
         pub struct $manager {
-            cache: scc::HashMap<TypeId, crate::BoxedAnyInstance>,
+            cache: scc::HashMap<TypeId, $crate::BoxedAnyInstance>,
         }
 
         impl $manager {

--- a/crates/framework/src/instance.rs
+++ b/crates/framework/src/instance.rs
@@ -1,3 +1,59 @@
+use scc::hash_map::OccupiedEntry;
+use std::any::{Any, TypeId};
+use std::ops::{Deref, DerefMut};
+
+pub type BoxedAnyInstance = Box<dyn Any + Sync + Send>;
+
+pub struct InstanceReadGuard<'i, T> {
+    pub value: &'i T,
+    entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>,
+}
+
+impl<'i, T> InstanceReadGuard<'i, T> {
+    pub fn new(entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>) -> Self {
+        InstanceReadGuard {
+            value: entry.get().downcast_ref::<T>().unwrap(),
+            entry,
+        }
+    }
+}
+
+impl<'i, T> Deref for InstanceReadGuard<'i, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+
+pub struct InstanceWriteGuard<'i, T> {
+    pub value: &'i mut T,
+    entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>,
+}
+
+impl<'i, T> InstanceWriteGuard<'i, T> {
+    pub fn new(mut entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>) -> Self {
+        InstanceWriteGuard {
+            value: entry.get_mut().downcast_mut::<T>().unwrap(),
+            entry,
+        }
+    }
+}
+
+impl<'i, T> Deref for InstanceWriteGuard<'i, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.value
+    }
+}
+
+impl<'i, T> DerefMut for InstanceWriteGuard<'i, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.value
+    }
+}
+
 // Creates a simple `Any` map registry of objects by type.
 // These methods `panic!` because it immediately bubbles up that
 // the order of operations for application state is wrong, and
@@ -14,15 +70,15 @@ macro_rules! create_instance_manager {
 
         #[derive(Debug, Default)]
         pub struct $manager {
-            cache: FxHashMap<TypeId, Box<dyn Any + Sync + Send>>,
+            cache: scc::HashMap<TypeId, crate::BoxedAnyInstance>,
         }
 
         impl $manager {
             /// Get an immutable instance reference for the provided type.
             /// If the instance does not exist, a panic will be triggered.
-            pub fn get<T: Any + Send + Sync + $type>(&self) -> &T {
-                if let Some(value) = self.cache.get(&TypeId::of::<T>()) {
-                    return value.downcast_ref::<T>().unwrap();
+            pub fn get<T: Any + Send + Sync + $type>(&self) -> crate::InstanceReadGuard<T> {
+                if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
+                    return crate::InstanceReadGuard::new(entry);
                 }
 
                 panic!("{} does not exist!", type_name::<T>())
@@ -30,9 +86,9 @@ macro_rules! create_instance_manager {
 
             /// Get a mutable instance reference for the provided type.
             /// If the instance does not exist, a panic will be triggered.
-            pub fn get_mut<T: Any + Send + Sync + $type>(&mut self) -> &mut T {
-                if let Some(value) = self.cache.get_mut(&TypeId::of::<T>()) {
-                    return value.downcast_mut::<T>().unwrap();
+            pub fn get_mut<T: Any + Send + Sync + $type>(&self) -> crate::InstanceWriteGuard<T> {
+                if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
+                    return crate::InstanceWriteGuard::new(entry);
                 }
 
                 panic!("{} does not exist!", type_name::<T>())
@@ -40,9 +96,8 @@ macro_rules! create_instance_manager {
 
             /// Set the instance into the registry with the provided type.
             /// If an exact type already exists, it'll be overwritten.
-            pub fn set<T: Any + Send + Sync + $type>(&mut self, instance: T) -> &mut Self {
+            pub fn set<T: Any + Send + Sync + $type>(&self, instance: T) {
                 self.cache.insert(TypeId::of::<T>(), Box::new(instance));
-                self
             }
         }
     };

--- a/crates/framework/src/instance.rs
+++ b/crates/framework/src/instance.rs
@@ -69,9 +69,9 @@ macro_rules! create_instance_manager {
         impl $manager {
             /// Get an instance reference for the provided type.
             /// If the instance does not exist, a panic will be triggered.
-            pub fn get<T: Any + Send + Sync + $type>(&self) -> crate::InstanceGuard<T> {
+            pub fn get<T: Any + Send + Sync + $type>(&self) -> $crate::InstanceGuard<T> {
                 if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
-                    return crate::InstanceGuard::new(entry);
+                    return $crate::InstanceGuard::new(entry);
                 }
 
                 panic!("{} does not exist!", type_name::<T>())

--- a/crates/framework/src/instance.rs
+++ b/crates/framework/src/instance.rs
@@ -1,5 +1,6 @@
 use scc::hash_map::OccupiedEntry;
 use std::any::{Any, TypeId};
+use std::fmt;
 use std::ops::{Deref, DerefMut};
 
 pub type BoxedAnyInstance = Box<dyn Any + Sync + Send>;
@@ -37,6 +38,12 @@ impl<'i, T: 'static> Deref for InstanceGuard<'i, T> {
 impl<'i, T: 'static> DerefMut for InstanceGuard<'i, T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.write()
+    }
+}
+
+impl<'i, T: fmt::Debug + 'static> fmt::Debug for InstanceGuard<'i, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.read())
     }
 }
 

--- a/crates/framework/src/instance.rs
+++ b/crates/framework/src/instance.rs
@@ -1,56 +1,27 @@
 use scc::hash_map::OccupiedEntry;
 use std::any::{Any, TypeId};
-use std::ops::{Deref, DerefMut};
 
 pub type BoxedAnyInstance = Box<dyn Any + Sync + Send>;
 
-pub struct InstanceReadGuard<'i, T> {
-    pub value: &'i T,
+pub struct InstanceGuard<'i, T> {
     entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>,
+    marker: std::marker::PhantomData<&'i T>,
 }
 
-impl<'i, T> InstanceReadGuard<'i, T> {
+impl<'i, T: 'static> InstanceGuard<'i, T> {
     pub fn new(entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>) -> Self {
-        InstanceReadGuard {
-            value: entry.get().downcast_ref::<T>().unwrap(),
+        InstanceGuard {
             entry,
+            marker: std::marker::PhantomData,
         }
     }
-}
 
-impl<'i, T> Deref for InstanceReadGuard<'i, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.value
+    pub fn read(&self) -> &T {
+        self.entry.get().downcast_ref::<T>().unwrap()
     }
-}
 
-pub struct InstanceWriteGuard<'i, T> {
-    pub value: &'i mut T,
-    entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>,
-}
-
-impl<'i, T> InstanceWriteGuard<'i, T> {
-    pub fn new(mut entry: OccupiedEntry<'i, TypeId, BoxedAnyInstance>) -> Self {
-        InstanceWriteGuard {
-            value: entry.get_mut().downcast_mut::<T>().unwrap(),
-            entry,
-        }
-    }
-}
-
-impl<'i, T> Deref for InstanceWriteGuard<'i, T> {
-    type Target = T;
-
-    fn deref(&self) -> &Self::Target {
-        self.value
-    }
-}
-
-impl<'i, T> DerefMut for InstanceWriteGuard<'i, T> {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        self.value
+    pub fn write(&mut self) -> &mut T {
+        self.entry.get_mut().downcast_mut::<T>().unwrap()
     }
 }
 
@@ -74,21 +45,11 @@ macro_rules! create_instance_manager {
         }
 
         impl $manager {
-            /// Get an immutable instance reference for the provided type.
+            /// Get an instance reference for the provided type.
             /// If the instance does not exist, a panic will be triggered.
-            pub fn get<T: Any + Send + Sync + $type>(&self) -> crate::InstanceReadGuard<T> {
+            pub fn get<T: Any + Send + Sync + $type>(&self) -> crate::InstanceGuard<T> {
                 if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
-                    return crate::InstanceReadGuard::new(entry);
-                }
-
-                panic!("{} does not exist!", type_name::<T>())
-            }
-
-            /// Get a mutable instance reference for the provided type.
-            /// If the instance does not exist, a panic will be triggered.
-            pub fn get_mut<T: Any + Send + Sync + $type>(&self) -> crate::InstanceWriteGuard<T> {
-                if let Some(entry) = self.cache.get(&TypeId::of::<T>()) {
-                    return crate::InstanceWriteGuard::new(entry);
+                    return crate::InstanceGuard::new(entry);
                 }
 
                 panic!("{} does not exist!", type_name::<T>())
@@ -97,7 +58,7 @@ macro_rules! create_instance_manager {
             /// Set the instance into the registry with the provided type.
             /// If an exact type already exists, it'll be overwritten.
             pub fn set<T: Any + Send + Sync + $type>(&self, instance: T) {
-                self.cache.insert(TypeId::of::<T>(), Box::new(instance));
+               let _ = self.cache.insert(TypeId::of::<T>(), Box::new(instance));
             }
         }
     };

--- a/crates/framework/src/lib.rs
+++ b/crates/framework/src/lib.rs
@@ -15,6 +15,7 @@ pub use app::*;
 pub use app_state::AppPhase;
 pub use args::*;
 pub use emitters::*;
+pub use instance::*;
 pub use resources::*;
 pub use starbase_macros::*;
 pub use states::*;

--- a/crates/framework/src/resources.rs
+++ b/crates/framework/src/resources.rs
@@ -1,11 +1,9 @@
 use crate::create_instance_manager;
-use rustc_hash::FxHashMap;
 use std::{
     any::{type_name, Any, TypeId},
     sync::Arc,
 };
-use tokio::sync::RwLock;
 
 create_instance_manager!(ResourceManager, ResourceInstance);
 
-pub type Resources = Arc<RwLock<ResourceManager>>;
+pub type Resources = Arc<ResourceManager>;

--- a/crates/framework/src/states.rs
+++ b/crates/framework/src/states.rs
@@ -1,10 +1,8 @@
 use crate::create_instance_manager;
-use rustc_hash::FxHashMap;
 use std::{
     any::{type_name, Any, TypeId},
     sync::Arc,
 };
-use tokio::sync::RwLock;
 
 create_instance_manager!(StateManager, StateInstance, {
     /// Extract the provided type from the state instance.
@@ -15,4 +13,4 @@ create_instance_manager!(StateManager, StateInstance, {
     }
 });
 
-pub type States = Arc<RwLock<StateManager>>;
+pub type States = Arc<StateManager>;

--- a/crates/framework/src/states.rs
+++ b/crates/framework/src/states.rs
@@ -8,7 +8,7 @@ create_instance_manager!(StateManager, StateInstance, {
     /// Extract the provided type from the state instance.
     /// If the type does not exist, or the state does not support
     /// extraction, [`None`] will be returned.
-    fn extract<T: Any + Send + Sync>(&self) -> Option<&T> {
+    fn extract<T: Any + Clone + Send + Sync>(&self) -> Option<T> {
         None
     }
 });

--- a/crates/framework/tests/instances_test.rs
+++ b/crates/framework/tests/instances_test.rs
@@ -16,13 +16,13 @@ mod events {
 
     #[tokio::test]
     async fn register_and_emit() {
-        let mut ctx = EmitterManager::default();
+        let ctx = EmitterManager::default();
         ctx.set(Emitter::<TestEvent>::new());
 
-        let em = ctx.get_mut::<Emitter<TestEvent>>();
-        em.on(callback_one).await;
+        let mut em = ctx.get::<Emitter<TestEvent>>();
+        em.write().on(callback_one).await;
 
-        let data = em.emit(TestEvent(5)).await.unwrap();
+        let data = em.write().emit(TestEvent(5)).await.unwrap();
 
         assert_eq!(data, 10);
     }
@@ -38,37 +38,30 @@ mod resources {
 
     #[test]
     fn register_and_read() {
-        let mut ctx = ResourceManager::default();
+        let ctx = ResourceManager::default();
         ctx.set(TestResource { field: 5 });
 
         let resource = ctx.get::<TestResource>();
 
-        assert_eq!(resource.field, 5);
+        assert_eq!(resource.read().field, 5);
     }
 
     #[test]
     fn register_and_write() {
-        let mut ctx = ResourceManager::default();
+        let ctx = ResourceManager::default();
         ctx.set(TestResource { field: 5 });
 
-        let resource = ctx.get_mut::<TestResource>();
-        resource.field += 5;
+        let mut resource = ctx.get::<TestResource>();
+        resource.write().field += 5;
 
-        assert_eq!(resource.field, 10);
+        assert_eq!(resource.read().field, 10);
     }
 
     #[test]
     #[should_panic(expected = "instances_test::resources::TestResource does not exist!")]
-    fn panics_missing_read() {
+    fn panics_missing() {
         let ctx = ResourceManager::default();
         ctx.get::<TestResource>();
-    }
-
-    #[test]
-    #[should_panic(expected = "instances_test::resources::TestResource does not exist!")]
-    fn panics_missing_write() {
-        let mut ctx = ResourceManager::default();
-        ctx.get_mut::<TestResource>();
     }
 }
 
@@ -80,36 +73,29 @@ mod state {
 
     #[test]
     fn register_and_read() {
-        let mut ctx = StateManager::default();
+        let ctx = StateManager::default();
         ctx.set(TestState(5));
 
         let state = ctx.get::<TestState>();
 
-        assert_eq!(state.0, 5);
+        assert_eq!(state.read().0, 5);
     }
 
     #[test]
     fn register_and_write() {
-        let mut ctx = StateManager::default();
+        let ctx = StateManager::default();
         ctx.set(TestState(5));
 
-        let state = ctx.get_mut::<TestState>();
-        (**state) += 5;
+        let mut state = ctx.get::<TestState>();
+        state.write().0 += 5;
 
-        assert_eq!(state.0, 10);
+        assert_eq!(state.read().0, 10);
     }
 
     #[test]
     #[should_panic(expected = "instances_test::state::TestState does not exist!")]
-    fn panics_missing_read() {
+    fn panics_missing() {
         let ctx = StateManager::default();
         ctx.get::<TestState>();
-    }
-
-    #[test]
-    #[should_panic(expected = "instances_test::state::TestState does not exist!")]
-    fn panics_missing_write() {
-        let mut ctx = StateManager::default();
-        ctx.get_mut::<TestState>();
     }
 }

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -179,6 +179,16 @@ fn non_async() {
     dbg!("none");
 }
 
+#[system]
+async fn manager_with_other_args(manager: States, arg: StateRef<State1>) {
+    dbg!(&manager);
+}
+
+#[system]
+async fn mut_manager_with_other_args(manager: States, arg: StateRef<State1>) {
+    manager.set(State1(123));
+}
+
 // INVALID
 
 // #[system]
@@ -186,7 +196,7 @@ fn non_async() {
 //     return Ok(123);
 // }
 
-// TODO?
+// // TODO?
 // #[system]
 // async fn fail_invalid_return_type() -> Result<usize> {
 //     dbg!("fail");
@@ -205,16 +215,6 @@ fn non_async() {
 // #[system]
 // async fn fail_unknown_wrapper_type(other: OtherRef<State1>) {
 //     dbg!(other);
-// }
-
-// #[system]
-// async fn fail_manager_with_other_args(manager: StatesRef, arg: StateRef<State1>) {
-//     dbg!(manager);
-// }
-
-// #[system]
-// async fn fail_mut_manager_with_other_args(manager: StatesMut, arg: StateRef<State1>) {
-//     manager.add_state(State1(123));
 // }
 
 // #[system]

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -22,18 +22,18 @@ struct Resource2 {
     pub field: usize,
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct SomeArgs {}
 
 // READ
 
 #[system]
-async fn read_states(states: StatesRef) {
+async fn read_states(states: States) {
     dbg!(states);
 }
 
 #[system]
-async fn read_states_renamed(other: StatesRef) {
+async fn read_states_renamed(other: States) {
     dbg!(other);
 }
 
@@ -65,12 +65,12 @@ async fn read_args_ref(args: ArgsRef<SomeArgs>) {
 }
 
 #[system]
-async fn read_resources(resources: ResourcesRef) {
+async fn read_resources(resources: Resources) {
     dbg!(resources);
 }
 
 #[system]
-async fn read_resources_renamed(other: ResourcesRef) {
+async fn read_resources_renamed(other: Resources) {
     dbg!(other);
 }
 
@@ -92,7 +92,7 @@ async fn read_resource_same_arg(arg1: ResourceRef<Resource1>, arg2: ResourceRef<
 }
 
 #[system]
-async fn read_emitters(emitters: EmittersRef) {
+async fn read_emitters(emitters: Emitters) {
     emitters.get::<Emitter<Event1>>();
 }
 
@@ -102,19 +102,19 @@ async fn read_emitter(em: EmitterRef<Event1>) {
 }
 
 #[system]
-async fn read_all_managers(states: StatesRef, resources: ResourcesRef, emitters: EmittersMut) {
+async fn read_all_managers(states: States, resources: Resources, emitters: Emitters) {
     dbg!(states, resources, emitters);
 }
 
 // WRITE
 
 #[system]
-async fn write_states(states: StatesMut) {
+async fn write_states(states: States) {
     states.set(State1(123));
 }
 
 #[system]
-async fn write_states_renamed(other: StatesMut) {
+async fn write_states_renamed(other: States) {
     dbg!(other);
 }
 
@@ -125,12 +125,12 @@ async fn write_state(arg: StateMut<State1>) {
 }
 
 #[system]
-async fn write_resources(resources: ResourcesMut) {
+async fn write_resources(resources: Resources) {
     resources.set(Resource1 { field: 123 });
 }
 
 #[system(instrument = false)]
-async fn write_resources_renamed(other: ResourcesMut) {
+async fn write_resources_renamed(other: Resources) {
     dbg!(other);
 }
 
@@ -141,12 +141,12 @@ async fn write_resource(arg: ResourceMut<Resource1>) {
 }
 
 #[system]
-async fn write_emitters(emitters: EmittersMut) {
+async fn write_emitters(emitters: Emitters) {
     emitters.set(Emitter::<Event1>::new());
 }
 
 #[system]
-async fn write_emitters_renamed(other: EmittersMut) {
+async fn write_emitters_renamed(other: Emitters) {
     dbg!(other);
 }
 
@@ -156,7 +156,7 @@ async fn write_emitter(em: EmitterMut<Event1>) {
 }
 
 #[system]
-async fn write_all_managers(states: StatesMut, resources: ResourcesMut, emitters: EmittersMut) {
+async fn write_all_managers(states: States, resources: Resources, emitters: Emitters) {
     states.set(State1(123));
     resources.set(Resource1 { field: 123 });
     emitters.set(Emitter::<Event1>::new());

--- a/crates/framework/tests/system_macros_test.rs
+++ b/crates/framework/tests/system_macros_test.rs
@@ -180,14 +180,17 @@ fn non_async() {
 }
 
 #[system]
-async fn manager_with_other_args(manager: States, arg: StateRef<State1>) {
+async fn manager_with_other_args(manager: States, _arg: StateRef<State1>) {
     dbg!(&manager);
 }
 
 #[system]
-async fn mut_manager_with_other_args(manager: States, arg: StateRef<State1>) {
+async fn mut_manager_with_other_args(manager: States, _arg: StateRef<State1>) {
     manager.set(State1(123));
 }
+
+#[system]
+async fn raw(_raw1: StateRaw<State2>, _raw2: StateRaw<State2>) {}
 
 // INVALID
 

--- a/crates/macros/src/system.rs
+++ b/crates/macros/src/system.rs
@@ -182,33 +182,31 @@ impl<'l> InstanceTracker<'l> {
                 SystemParam::ParamMut(ty) => {
                     if is_emitter {
                         quotes.push(quote! {
-                            let mut #base_name = #manager_var_name.get::<starbase::Emitter<#ty>>();
-                            let mut #name = #base_name.write();
+                            let mut #name = #manager_var_name.get::<starbase::Emitter<#ty>>();
                         });
                     } else {
                         quotes.push(quote! {
-                            let mut #base_name = #manager_var_name.get::<#ty>();
-                            let mut #name = #base_name.write();
+                            let mut #name = #manager_var_name.get::<#ty>();
                         });
                     }
                 }
                 SystemParam::ParamRef(ty) => {
                     if is_emitter {
                         quotes.push(quote! {
-                            let #base_name = #manager_var_name.get::<starbase::Emitter<#ty>>();
-                            let #name = #base_name.read();
+                            let #name = #manager_var_name.get::<starbase::Emitter<#ty>>();
                         });
                     } else {
                         quotes.push(quote! {
-                            let #base_name = #manager_var_name.get::<#ty>();
-                            let #name = #base_name.read();
+                            let #name = #manager_var_name.get::<#ty>();
                         });
                     }
                 }
                 SystemParam::ParamRefWithExtract(ty, extract_ty) => {
                     quotes.push(quote! {
-                        let #base_name = #manager_var_name.get::<#ty>();
-                        let #name = #base_name.read().extract::<#extract_ty>().unwrap();
+                        let #name = {
+                            let #base_name = #manager_var_name.get::<#ty>();
+                            #base_name.read().extract::<#extract_ty>().unwrap()
+                        };
                     });
                 }
                 SystemParam::ArgsRef(ty) => {
@@ -218,8 +216,10 @@ impl<'l> InstanceTracker<'l> {
                     }
 
                     quotes.push(quote! {
-                        let #base_name = #manager_var_name.get::<starbase::ExecuteArgs>();
-                        let #name = #base_name.read().extract::<#ty>().unwrap();
+                        let #name = {
+                            let #base_name = #manager_var_name.get::<starbase::ExecuteArgs>();
+                            #base_name.read().extract::<#ty>().unwrap()
+                        };
                     });
                 } // _ => unimplemented!(),
             };

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -98,6 +98,22 @@ async fn finish(state: StateRef<TestState>) {
 //     }
 // }
 
+// SOMETIMES HANGS!
+#[system]
+async fn raw_write_write(state1: StateRaw<TestState>, state2: StateRaw<TestState2>) {
+    dbg!(&state1);
+    {
+        state1.write().0 = "updated".into();
+    }
+    dbg!(&state1);
+
+    dbg!(&state2);
+    {
+        state2.write().0 = false;
+    }
+    dbg!(&state2);
+}
+
 #[system]
 async fn create_file() {
     test_lib::create_file()?;
@@ -139,6 +155,7 @@ async fn main() -> MainResult {
     // app.execute(missing_file);
     // app.execute(read_write);
     // app.execute(write_write);
+    // app.execute(raw_write_write);
     // app.execute(create_file);
     app.execute(fail);
 

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -18,6 +18,9 @@ enum AppError {
 #[derive(Debug, State)]
 struct TestState(pub String);
 
+#[derive(Debug, State)]
+struct TestState2(pub bool);
+
 #[derive(Debug, Event)]
 #[event(dataset = usize)]
 struct TestEvent;
@@ -31,6 +34,7 @@ async fn update_event(mut data: TestEvent) {
 async fn start_one(states: States, emitters: Emitters) {
     info!("startup 1");
     states.set(TestState("original".into()));
+    states.set(TestState2(true));
     emitters.set(Emitter::<TestEvent>::new());
     debug!("startup 1");
 }
@@ -72,6 +76,28 @@ async fn finish(state: StateRef<TestState>) {
     // dbg!(state);
 }
 
+// HANGS!
+// #[system]
+// async fn read_write(state1: StateRef<TestState>, state2: StateMut<TestState2>) {
+//     {
+//         state2.0 = false;
+//     }
+
+//     dbg!(&state1);
+// }
+
+// HANGS!
+// #[system]
+// async fn write_write(state1: StateMut<TestState>, state2: StateMut<TestState2>) {
+//     {
+//         state1.0 = "updated".into();
+//     }
+
+//     {
+//         state2.0 = false;
+//     }
+// }
+
 #[system]
 async fn create_file() {
     test_lib::create_file()?;
@@ -111,7 +137,9 @@ async fn main() -> MainResult {
     app.startup(start_one);
     app.startup(sub_mod::start_two);
     // app.execute(missing_file);
-    app.execute(create_file);
+    // app.execute(read_write);
+    // app.execute(write_write);
+    // app.execute(create_file);
     app.execute(fail);
 
     let ctx = app.run().await?;

--- a/crates/test-app/src/main.rs
+++ b/crates/test-app/src/main.rs
@@ -28,7 +28,7 @@ async fn update_event(mut data: TestEvent) {
 }
 
 #[system]
-async fn start_one(states: StatesMut, emitters: EmittersMut) {
+async fn start_one(states: States, emitters: Emitters) {
     info!("startup 1");
     states.set(TestState("original".into()));
     emitters.set(Emitter::<TestEvent>::new());
@@ -43,7 +43,6 @@ mod sub_mod {
         em.on(update_event).await;
 
         tokio::spawn(async move {
-            let states = states.read().await;
             info!("startup 2");
             let _ = states.get::<TestState>();
 


### PR DESCRIPTION
This allows us to use heavy interior mutability and remove all the `RwLock` usage. Better API? TBD.