### PR TITLE
fix: correct nu shell syntax

### DIFF
--- a/crates/shell/src/shells/nu.rs
+++ b/crates/shell/src/shells/nu.rs
@@ -220,19 +220,19 @@ mod tests {
         assert_eq!(
             Nu.format_path_set(&["$PROTO_HOME/shims".into(), "$PROTO_HOME/bin".into()])
                 .replace("\r\n", "\n"),
-            r#"$env.Path = $env.Path | split row (char esep)
+            r#"$env.Path = ($env.Path | split row (char esep)
   | prepend ($env.PROTO_HOME | path join bin)
   | prepend ($env.PROTO_HOME | path join shims)
-  | uniq"#
+  | uniq)"#
         );
 
         assert_eq!(
             Nu.format_path_set(&["$HOME/with/sub/dir".into(), "/some/abs/path/bin".into()])
                 .replace("\r\n", "\n"),
-            r#"$env.Path = $env.Path | split row (char esep)
+            r#"$env.Path = ($env.Path | split row (char esep)
   | prepend /some/abs/path/bin
   | prepend ($env.HOME | path join with sub dir)
-  | uniq"#
+  | uniq)"#
         );
     }
 


### PR DESCRIPTION
# Fix Nushell path and environment variable handling

## Description
This PR addresses issues with path and environment variable handling in Nushell scripts. It improves the formatting of PATH modifications and environment variable assignments to ensure proper execution and follow Nushell best practices.

## Changes
1. Modified `format_path_set` function to wrap the entire PATH modification in parentheses.
2. Updated `SetEnv` handling to use Nushell's `path join` for paths starting with `$HOME/`.
3. Adjusted test cases to reflect these changes.

## Specific changes

In format_path_set:
```rust
let mut value = format!("$env.{key} = ($env.{orig_key} | split row (char esep)\n");
// ...
value.push_str("  | uniq)");
```
In SetEnv handling:
```rust
Statement::SetEnv { key, value } => {
    if value.starts_with("$HOME/") {
        let path = value.trim_start_matches("$HOME/");
        format!("$env.{} = ($env.HOME | path join '{}')", key, path)
    } else {
        format!("$env.{} = {}", key, self.quote(value))
    }
}
```



Updated test cases to match new formatting:
```rust
assert_eq!(
    Nu.format_env_set("PROTO_HOME", "$HOME/.proto"),
    r#"$env.PROTO_HOME = ($env.HOME | path join '.proto')"#
);

assert_eq!(
    Nu.format_path_set(&["$PROTO_HOME/shims".into(), "$PROTO_HOME/bin".into()]),
    r#"$env.PATH = ($env.PATH | split row (char esep)
  | prepend ($env.PROTO_HOME | path join bin)
  | prepend ($env.PROTO_HOME | path join shims)
  | uniq)"#
);
```

## Rationale
These changes ensure that PATH modifications are evaluated as a single expression before assignment, preventing potential issues with operator precedence.

## Testing
The existing tests have been updated to reflect these changes. All tests pass with the new implementation.

