### PR TITLE
Use a `Out-String` cmdlet to force exports to be string type

### DIFF
--- a/crates/shell/src/shells/pwsh.rs
+++ b/crates/shell/src/shells/pwsh.rs
@@ -109,7 +109,7 @@ $origPath = [Environment]::GetEnvironmentVariable('PATH')
 function {function} {{
   $exports = {command};
   if ($exports) {{
-    Invoke-Expression -Command $exports;
+    $exports | Out-String | Invoke-Expression;
   }}
 }}
 

--- a/crates/shell/src/shells/snapshots/starbase_shell__shells__pwsh__tests__formats_cd_hook.snap
+++ b/crates/shell/src/shells/snapshots/starbase_shell__shells__pwsh__tests__formats_cd_hook.snap
@@ -11,7 +11,7 @@ $origPath = [Environment]::GetEnvironmentVariable('PATH')
 function _starbase_hook {
   $exports = starbase hook pwsh;
   if ($exports) {
-    Invoke-Expression -Command $exports;
+    $exports | Out-String | Invoke-Expression;
   }
 }
 


### PR DESCRIPTION
Tested in pwsh only, not tested in Rust environment.