### PR TITLE
Add OpenTelemetry traces, metrics, and logs support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,6 +135,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +397,18 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "const-hex"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531185e432bb31db1ecda541e9e7ab21468d4d844ad7505e0546a49b4945d49b"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "proptest",
+ "serde_core",
 ]
 
 [[package]]
@@ -784,6 +839,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -988,6 +1049,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be136d9dacc2a13cc70bb6c8f902b414fb2641f8db1314637c6b7933411a8f82"
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1068,9 +1154,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1090,6 +1178,19 @@ dependencies = [
  "rustls",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1558,6 +1659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1592,6 +1699,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1711,6 +1824,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-appender-tracing"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+dependencies = [
+ "opentelemetry",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+dependencies = [
+ "http",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+dependencies = [
+ "base64",
+ "const-hex",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "serde",
+ "serde_json",
+ "tonic",
+ "tonic-prost",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry",
+ "percent-encoding",
+ "rand",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1792,6 +1981,26 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1899,6 +2108,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags",
+ "num-traits",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2249,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2611,11 +2867,20 @@ dependencies = [
  "async-trait",
  "chrono",
  "miette",
+ "opentelemetry",
+ "opentelemetry-appender-tracing",
+ "opentelemetry-otlp",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "serial_test",
  "starbase_styles",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
  "tracing-chrome",
  "tracing-log",
+ "tracing-opentelemetry",
  "tracing-subscriber",
 ]
 
@@ -3012,6 +3277,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3340,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
+name = "tonic"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "socket2",
+ "sync_wrapper",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55376a0bbaa4975a3f10d009ad763d8f4108f067c7c2e74f3001fb49778d309"
+dependencies = [
+ "bytes",
+ "prost",
+ "tonic",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3058,11 +3387,15 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
+ "indexmap",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3150,6 +3483,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+dependencies = [
+ "js-sys",
+ "opentelemetry",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3190,6 +3539,12 @@ name = "ucd-trie"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicode-ident"

--- a/crates/app/Cargo.toml
+++ b/crates/app/Cargo.toml
@@ -20,6 +20,19 @@ chrono = { version = "0.4.44", default-features = false, features = [
 	"std",
 ] }
 miette = { workspace = true, features = ["fancy"] }
+opentelemetry = { version = "0.31.0", optional = true, features = ["logs", "metrics"] }
+opentelemetry-appender-tracing = { version = "0.31.1", optional = true }
+opentelemetry-otlp = { version = "0.31.1", optional = true, default-features = false, features = [
+	"grpc-tonic",
+	"logs",
+	"metrics",
+	"trace",
+] }
+opentelemetry_sdk = { version = "0.31.0", optional = true, features = [
+	"logs",
+	"metrics",
+	"rt-tokio",
+] }
 tokio = { workspace = true }
 tracing = { workspace = true, optional = true }
 tracing-chrome = { version = "0.7.2", optional = true }
@@ -27,13 +40,29 @@ tracing-log = { version = "0.2.0", optional = true, default-features = false, fe
 	"log-tracer",
 	"std",
 ] }
+tracing-opentelemetry = { version = "0.32.1", optional = true }
 tracing-subscriber = { version = "0.3.23", optional = true, default-features = false, features = [
 	"ansi",
 	"env-filter",
 	"fmt",
 ] }
 
+[dev-dependencies]
+opentelemetry-proto = "0.31.0"
+serial_test = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { version = "0.1.18", features = ["net"] }
+tonic = "0.14.5"
+
 [features]
 default = ["tracing"]
+otel = [
+	"dep:opentelemetry",
+	"dep:opentelemetry-appender-tracing",
+	"dep:opentelemetry-otlp",
+	"dep:opentelemetry_sdk",
+	"dep:tracing-opentelemetry",
+	"tracing",
+]
 tracing = ["dep:tracing", "dep:tracing-chrome", "dep:tracing-subscriber"]
 log-compat = ["dep:tracing-log"]

--- a/crates/app/README.md
+++ b/crates/app/README.md
@@ -97,13 +97,33 @@ use starbase::{App, MainResult};
 async fn main() -> MainResult {
   let app = App::default();
   app.setup_diagnostics();
-  app.setup_tracing_with_defaults();
+  app.setup_tracing_with_defaults()?;
 
   // ...
 
   Ok(())
 }
 ```
+
+## OpenTelemetry tracing
+
+When the `otel` feature is enabled, `TracingOptions` can also export traces and metrics over OTLP.
+
+```rust
+use starbase::tracing::{OtelOptions, TracingOptions};
+
+let _guard = app.setup_tracing(TracingOptions {
+    otel: OtelOptions {
+        enabled: true,
+        logs_enabled: false,
+        service_name: Some("my-app".into()),
+    },
+    ..TracingOptions::default()
+})?;
+```
+
+This wires the OTLP tracing and metrics bridge. Endpoint, protocol, headers, and other exporter behavior
+should still be configured through the standard OpenTelemetry environment variables.
 
 To make the most out of errors, and in turn diagnostics, it's best (also suggested) to use the
 `thiserror` crate.

--- a/crates/app/src/app.rs
+++ b/crates/app/src/app.rs
@@ -1,10 +1,17 @@
 use crate::session::{AppResult, AppSession};
+#[cfg(feature = "tracing")]
 use crate::tracing::TracingOptions;
 use miette::IntoDiagnostic;
 use std::process::ExitCode;
 use tokio::spawn;
 use tokio::task::JoinHandle;
+#[cfg(feature = "tracing")]
 use tracing::{instrument, trace};
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! trace {
+    ($($arg:tt)*) => {};
+}
 
 /// A result for `main` that handles errors and exit codes.
 pub type MainResult = miette::Result<ExitCode>;
@@ -34,13 +41,18 @@ impl App {
 
     /// Setup `tracing` messages with default options.
     #[cfg(feature = "tracing")]
-    pub fn setup_tracing_with_defaults(&self) -> crate::tracing::TracingGuard {
+    pub fn setup_tracing_with_defaults(
+        &self,
+    ) -> crate::tracing::TracingResult<crate::tracing::TracingGuard> {
         self.setup_tracing(TracingOptions::default())
     }
 
     /// Setup `tracing` messages with custom options.
     #[cfg(feature = "tracing")]
-    pub fn setup_tracing(&self, options: TracingOptions) -> crate::tracing::TracingGuard {
+    pub fn setup_tracing(
+        &self,
+        options: TracingOptions,
+    ) -> crate::tracing::TracingResult<crate::tracing::TracingGuard> {
         crate::tracing::setup_tracing(options)
     }
 
@@ -60,7 +72,7 @@ impl App {
     ///
     /// This method is similar to [`App#run`](#method.run) but doesn't consume
     /// the session, and instead accepts a mutable reference.
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     pub async fn run_with_session<S, F, Fut>(mut self, session: &mut S, op: F) -> miette::Result<u8>
     where
         S: AppSession + 'static,
@@ -96,7 +108,7 @@ impl App {
 
     // Private
 
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     async fn run_startup<S>(&mut self, session: &mut S) -> miette::Result<()>
     where
         S: AppSession,
@@ -109,7 +121,7 @@ impl App {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     async fn run_analyze<S>(&mut self, session: &mut S) -> miette::Result<()>
     where
         S: AppSession,
@@ -122,7 +134,7 @@ impl App {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     async fn run_execute<S, F, Fut>(&mut self, session: &mut S, op: F) -> miette::Result<()>
     where
         S: AppSession + 'static,
@@ -147,7 +159,7 @@ impl App {
         Ok(())
     }
 
-    #[instrument(skip_all)]
+    #[cfg_attr(feature = "tracing", instrument(skip_all))]
     async fn run_shutdown<S>(
         &mut self,
         session: &mut S,
@@ -156,9 +168,13 @@ impl App {
     where
         S: AppSession,
     {
-        if let Some(error) = error {
+        if error.is_some() {
             trace!("Running shutdown phase (because another phase failed)");
-            trace!("Error: {error}");
+
+            #[cfg(feature = "tracing")]
+            if let Some(error) = error {
+                trace!("Error: {error}");
+            }
         } else {
             trace!("Running shutdown phase");
         }

--- a/crates/app/src/diagnostics.rs
+++ b/crates/app/src/diagnostics.rs
@@ -2,7 +2,7 @@ use starbase_styles::theme::create_graphical_theme;
 
 pub use miette::*;
 
-#[tracing::instrument]
+#[cfg_attr(feature = "tracing", tracing::instrument)]
 pub fn setup_miette() {
     miette::set_panic_hook();
 

--- a/crates/app/src/tracing/mod.rs
+++ b/crates/app/src/tracing/mod.rs
@@ -1,24 +1,63 @@
 mod format;
 mod level;
+#[cfg(feature = "otel")]
+mod otel;
 
 use crate::tracing::format::*;
+pub use crate::tracing::level::LogLevel;
+#[cfg(feature = "otel")]
+pub use crate::tracing::otel::OtelOptions;
+use std::error::Error;
 use std::fs::File;
 use std::io;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::Ordering;
 use std::time::SystemTime;
-use std::{env, fs};
+use std::{env, fmt as std_fmt, fs};
 use tracing::subscriber::set_global_default;
-use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
-use tracing_subscriber::fmt::{self, SubscriberBuilder};
-use tracing_subscriber::{EnvFilter, prelude::*};
-
-pub use crate::tracing::level::LogLevel;
 pub use tracing::{
     debug, debug_span, enabled, error, error_span, event, event_enabled, info, info_span,
     instrument, span, span_enabled, trace, trace_span, warn, warn_span,
 };
+use tracing_chrome::{ChromeLayerBuilder, FlushGuard};
+use tracing_subscriber::fmt::{self, SubscriberBuilder};
+use tracing_subscriber::{EnvFilter, prelude::*};
+
+pub type TracingResult<T> = Result<T, TracingError>;
+
+#[derive(Debug)]
+pub struct TracingError {
+    message: String,
+    source: Option<Box<dyn Error + Send + Sync>>,
+}
+
+impl TracingError {
+    #[cfg(feature = "otel")]
+    pub(super) fn otlp_exporter(
+        signal: &'static str,
+        source: impl Error + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            message: format!("failed to initialize OTLP {signal} exporter"),
+            source: Some(Box::new(source)),
+        }
+    }
+}
+
+impl std_fmt::Display for TracingError {
+    fn fmt(&self, f: &mut std_fmt::Formatter<'_>) -> std_fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl Error for TracingError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        self.source
+            .as_deref()
+            .map(|source| source as &(dyn Error + 'static))
+    }
+}
 
 pub struct TracingOptions {
     /// Minimum level of messages to display.
@@ -35,6 +74,9 @@ pub struct TracingOptions {
     pub log_env: String,
     /// Absolute path to a file to write logs to.
     pub log_file: Option<PathBuf>,
+    /// OpenTelemetry export settings.
+    #[cfg(feature = "otel")]
+    pub otel: OtelOptions,
     /// Show span hierarchy in log output.
     pub show_spans: bool,
     /// Name of the testing environment variable.
@@ -51,6 +93,8 @@ impl Default for TracingOptions {
             intercept_log: true,
             log_env: "STARBASE_LOG".into(),
             log_file: None,
+            #[cfg(feature = "otel")]
+            otel: OtelOptions::default(),
             show_spans: false,
             test_env: "STARBASE_TEST".into(),
         }
@@ -60,10 +104,12 @@ impl Default for TracingOptions {
 pub struct TracingGuard {
     chrome_guard: Option<FlushGuard>,
     log_file: Option<Arc<File>>,
+    #[cfg(feature = "otel")]
+    otel_guard: Option<otel::OtelGuard>,
 }
 
 #[tracing::instrument(skip_all)]
-pub fn setup_tracing(options: TracingOptions) -> TracingGuard {
+pub fn setup_tracing(options: TracingOptions) -> TracingResult<TracingGuard> {
     TEST_ENV.store(env::var(options.test_env).is_ok(), Ordering::Release);
 
     // Determine modules to log
@@ -108,42 +154,51 @@ pub fn setup_tracing(options: TracingOptions) -> TracingGuard {
     let mut guard = TracingGuard {
         chrome_guard: None,
         log_file: None,
+        #[cfg(feature = "otel")]
+        otel_guard: None,
     };
 
-    let _ = set_global_default(
+    let subscriber = subscriber
+        // Write to a log file
+        .with(if let Some(log_file) = options.log_file {
+            if let Some(dir) = log_file.parent() {
+                fs::create_dir_all(dir).expect("Failed to create log directory.");
+            }
+
+            let file = Arc::new(File::create(log_file).expect("Failed to create log file."));
+
+            guard.log_file = Some(Arc::clone(&file));
+
+            Some(fmt::layer().with_ansi(false).with_writer(file))
+        } else {
+            None
+        })
+        // Dump a trace profile
+        .with(if options.dump_trace {
+            let (chrome_layer, chrome_guard) = ChromeLayerBuilder::new()
+                .include_args(true)
+                .include_locations(true)
+                .file(format!(
+                    "./dump-{}.json",
+                    SystemTime::UNIX_EPOCH.elapsed().unwrap().as_micros()
+                ))
+                .build();
+
+            guard.chrome_guard = Some(chrome_guard);
+
+            Some(chrome_layer)
+        } else {
+            None
+        });
+
+    #[cfg(feature = "otel")]
+    let subscriber = {
+        let (subscriber, otel_guard) = otel::extend_subscriber(subscriber, &options.otel)?;
+        guard.otel_guard = Some(otel_guard);
         subscriber
-            // Write to a log file
-            .with(if let Some(log_file) = options.log_file {
-                if let Some(dir) = log_file.parent() {
-                    fs::create_dir_all(dir).expect("Failed to create log directory.");
-                }
+    };
 
-                let file = Arc::new(File::create(log_file).expect("Failed to create log file."));
+    let _ = set_global_default(subscriber);
 
-                guard.log_file = Some(Arc::clone(&file));
-
-                Some(fmt::layer().with_ansi(false).with_writer(file))
-            } else {
-                None
-            })
-            // Dump a trace profile
-            .with(if options.dump_trace {
-                let (chrome_layer, chrome_guard) = ChromeLayerBuilder::new()
-                    .include_args(true)
-                    .include_locations(true)
-                    .file(format!(
-                        "./dump-{}.json",
-                        SystemTime::UNIX_EPOCH.elapsed().unwrap().as_micros()
-                    ))
-                    .build();
-
-                guard.chrome_guard = Some(chrome_guard);
-
-                Some(chrome_layer)
-            } else {
-                None
-            }),
-    );
-
-    guard
+    Ok(guard)
 }

--- a/crates/app/src/tracing/otel.rs
+++ b/crates/app/src/tracing/otel.rs
@@ -1,0 +1,231 @@
+use crate::tracing::{TracingError, TracingResult};
+use opentelemetry::global;
+use opentelemetry::metrics::MeterProvider as _;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
+use opentelemetry_otlp::{LogExporter, MetricExporter, SpanExporter};
+use opentelemetry_sdk::{
+    Resource,
+    logs::SdkLoggerProvider,
+    metrics::{PeriodicReader, SdkMeterProvider},
+    trace::SdkTracerProvider,
+};
+use std::env;
+use tracing::Subscriber;
+use tracing_subscriber::{Layer, layer::SubscriberExt, registry::LookupSpan};
+
+const OTEL_INSTRUMENTATION_SCOPE: &str = env!("CARGO_PKG_NAME");
+
+#[derive(Default)]
+pub struct OtelOptions {
+    /// Whether to export traces and metrics over OTLP.
+    pub enabled: bool,
+    /// Whether to export tracing events as OTLP logs.
+    pub logs_enabled: bool,
+    /// Service name recorded in the emitted telemetry resource.
+    pub service_name: Option<String>,
+}
+
+// OTEL providers do shut down on drop, but only when the last cloned handle is
+// dropped. The tracing subscriber, trace layer, and global meter provider can
+// all retain handles past TracingGuard, so keep the original providers here and
+// shut them down explicitly when the guard drops. This makes short-lived CLI
+// runs flush traces, metrics, and logs before exit.
+pub(super) struct OtelGuard {
+    logger_provider: Option<SdkLoggerProvider>,
+    meter_provider: Option<SdkMeterProvider>,
+    tracer_provider: Option<SdkTracerProvider>,
+}
+
+fn get_otel_service_name(options: &OtelOptions) -> String {
+    options
+        .service_name
+        .clone()
+        .or_else(|| {
+            env::current_exe().ok().and_then(|path| {
+                path.file_stem()
+                    .and_then(|stem| stem.to_str())
+                    .map(ToOwned::to_owned)
+            })
+        })
+        .unwrap_or_else(|| "starbase-app".into())
+}
+
+fn get_otel_resource(options: &OtelOptions) -> Resource {
+    Resource::builder()
+        .with_service_name(get_otel_service_name(options))
+        .build()
+}
+
+fn report_otel_shutdown_error(signal: &str, error: impl std::fmt::Display) {
+    eprintln!("Failed to shut down OTLP {signal} exporter: {error}");
+}
+
+impl Drop for OtelGuard {
+    fn drop(&mut self) {
+        if let Some(provider) = self.logger_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            report_otel_shutdown_error("logs", error);
+        }
+
+        if let Some(provider) = self.meter_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            report_otel_shutdown_error("metrics", error);
+        }
+
+        if let Some(provider) = self.tracer_provider.take()
+            && let Err(error) = provider.shutdown()
+        {
+            report_otel_shutdown_error("traces", error);
+        }
+    }
+}
+
+fn setup_otel_tracing(
+    options: &OtelOptions,
+    resource: Resource,
+) -> TracingResult<Option<SdkTracerProvider>> {
+    if !options.enabled {
+        return Ok(None);
+    }
+
+    let exporter = SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .map_err(|error| TracingError::otlp_exporter("traces", error))?;
+
+    Ok(Some(
+        SdkTracerProvider::builder()
+            .with_resource(resource)
+            .with_batch_exporter(exporter)
+            .build(),
+    ))
+}
+
+fn setup_otel_metrics(
+    options: &OtelOptions,
+    resource: Resource,
+) -> TracingResult<Option<SdkMeterProvider>> {
+    if !options.enabled {
+        return Ok(None);
+    }
+
+    let exporter = MetricExporter::builder()
+        .with_tonic()
+        .build()
+        .map_err(|error| TracingError::otlp_exporter("metrics", error))?;
+
+    let reader = PeriodicReader::builder(exporter).build();
+
+    Ok(Some(
+        SdkMeterProvider::builder()
+            .with_reader(reader)
+            .with_resource(resource)
+            .build(),
+    ))
+}
+
+fn setup_otel_logs(
+    options: &OtelOptions,
+    resource: Resource,
+) -> TracingResult<Option<SdkLoggerProvider>> {
+    if !options.logs_enabled {
+        return Ok(None);
+    }
+
+    // Logs are opt-in separately because exporting every tracing event can be
+    // much noisier than exporting spans and product metrics.
+    let exporter = LogExporter::builder()
+        .with_tonic()
+        .build()
+        .map_err(|error| TracingError::otlp_exporter("logs", error))?;
+
+    Ok(Some(
+        SdkLoggerProvider::builder()
+            .with_batch_exporter(exporter)
+            .with_resource(resource)
+            .build(),
+    ))
+}
+
+pub(super) fn extend_subscriber<S>(
+    subscriber: S,
+    options: &OtelOptions,
+) -> TracingResult<(impl Subscriber + Send + Sync + 'static, OtelGuard)>
+where
+    S: Subscriber + for<'span> LookupSpan<'span> + Send + Sync + 'static,
+{
+    let resource = get_otel_resource(options);
+    let logger_provider = setup_otel_logs(options, resource.clone())?;
+    let meter_provider = setup_otel_metrics(options, resource.clone())?;
+    let tracer_provider = setup_otel_tracing(options, resource)?;
+
+    if let Some(provider) = &meter_provider {
+        // Product code records metrics through OpenTelemetry's global meter
+        // provider, while spans/logs are bridged through tracing layers.
+        global::set_meter_provider(provider.clone());
+        let _ = provider.meter(OTEL_INSTRUMENTATION_SCOPE);
+    }
+
+    // Optional layers keep disabled signals out of the subscriber without
+    // changing the subscriber type shape.
+    let log_layer = logger_provider
+        .as_ref()
+        .map(OpenTelemetryTracingBridge::new)
+        .boxed();
+    let trace_layer = tracer_provider
+        .as_ref()
+        .map(|provider| {
+            tracing_opentelemetry::layer().with_tracer(provider.tracer(OTEL_INSTRUMENTATION_SCOPE))
+        })
+        .boxed();
+
+    Ok((
+        subscriber.with(log_layer).with(trace_layer),
+        OtelGuard {
+            logger_provider,
+            meter_provider,
+            tracer_provider,
+        },
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefers_explicit_service_name() {
+        assert_eq!(
+            get_otel_service_name(&OtelOptions {
+                enabled: true,
+                logs_enabled: false,
+                service_name: Some("starbase-test".into()),
+            }),
+            "starbase-test"
+        );
+    }
+
+    #[test]
+    fn disables_otel_when_not_enabled() {
+        let resource = get_otel_resource(&OtelOptions::default());
+
+        assert!(
+            setup_otel_tracing(&OtelOptions::default(), resource.clone())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            setup_otel_metrics(&OtelOptions::default(), resource.clone())
+                .unwrap()
+                .is_none()
+        );
+        assert!(
+            setup_otel_logs(&OtelOptions::default(), resource)
+                .unwrap()
+                .is_none()
+        );
+    }
+}

--- a/crates/app/tests/tracing_otel_test.rs
+++ b/crates/app/tests/tracing_otel_test.rs
@@ -1,0 +1,318 @@
+#![cfg(feature = "otel")]
+
+use opentelemetry::{KeyValue, global};
+use opentelemetry_proto::tonic::collector::logs::v1::{
+    ExportLogsServiceRequest, ExportLogsServiceResponse,
+    logs_service_server::{LogsService, LogsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+    metrics_service_server::{MetricsService, MetricsServiceServer},
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+    trace_service_server::{TraceService, TraceServiceServer},
+};
+use serial_test::serial;
+use starbase::tracing::{OtelOptions, TracingOptions, info, info_span, setup_tracing};
+use std::env;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Mutex, oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status, transport::Server};
+
+#[derive(Clone, Default)]
+struct Collector {
+    log_requests: Arc<Mutex<Vec<ExportLogsServiceRequest>>>,
+    metric_requests: Arc<Mutex<Vec<ExportMetricsServiceRequest>>>,
+    trace_requests: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+}
+
+#[tonic::async_trait]
+impl LogsService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportLogsServiceRequest>,
+    ) -> Result<Response<ExportLogsServiceResponse>, Status> {
+        self.log_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportLogsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl MetricsService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportMetricsServiceRequest>,
+    ) -> Result<Response<ExportMetricsServiceResponse>, Status> {
+        self.metric_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportMetricsServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tonic::async_trait]
+impl TraceService for Collector {
+    async fn export(
+        &self,
+        request: Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        self.trace_requests.lock().await.push(request.into_inner());
+
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+struct EnvVarGuard {
+    key: &'static str,
+    old_value: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: String) -> Self {
+        let old_value = env::var(key).ok();
+
+        unsafe {
+            env::set_var(key, value);
+        }
+
+        Self { key, old_value }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        if let Some(value) = &self.old_value {
+            unsafe {
+                env::set_var(self.key, value);
+            }
+        } else {
+            unsafe {
+                env::remove_var(self.key);
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[serial]
+async fn exports_spans_over_otlp() {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let log_requests = Arc::new(Mutex::new(Vec::new()));
+    let metric_requests = Arc::new(Mutex::new(Vec::new()));
+    let trace_requests = Arc::new(Mutex::new(Vec::new()));
+    let collector = Collector {
+        log_requests: Arc::clone(&log_requests),
+        metric_requests: Arc::clone(&metric_requests),
+        trace_requests: Arc::clone(&trace_requests),
+    };
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
+
+    let server = tokio::spawn(async move {
+        Server::builder()
+            .add_service(
+                LogsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(
+                MetricsServiceServer::new(collector.clone())
+                    .max_decoding_message_size(32 * 1024 * 1024),
+            )
+            .add_service(TraceServiceServer::new(collector))
+            .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .unwrap();
+    });
+
+    let _endpoint = EnvVarGuard::set(
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        format!("http://{addr}"),
+    );
+    let _protocol = EnvVarGuard::set("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc".into());
+    let _metrics_endpoint = EnvVarGuard::set(
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+        format!("http://{addr}"),
+    );
+    let _metrics_protocol = EnvVarGuard::set("OTEL_EXPORTER_OTLP_METRICS_PROTOCOL", "grpc".into());
+    let _logs_endpoint =
+        EnvVarGuard::set("OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", format!("http://{addr}"));
+    let _logs_protocol = EnvVarGuard::set("OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "grpc".into());
+
+    let guard = setup_tracing(TracingOptions {
+        otel: OtelOptions {
+            enabled: true,
+            logs_enabled: true,
+            service_name: Some("starbase-test".into()),
+        },
+        ..TracingOptions::default()
+    })
+    .unwrap();
+
+    let span = info_span!("otlp-test-span", phase = "execute");
+    let _entered = span.enter();
+    info!("hello from starbase");
+    let meter = global::meter("starbase-test-meter");
+    let counter = meter.u64_counter("starbase.test.counter").build();
+    let histogram = meter
+        .u64_histogram("starbase.test.duration")
+        .with_unit("ms")
+        .build();
+
+    counter.add(1, &[KeyValue::new("kind", "smoke")]);
+    histogram.record(42, &[KeyValue::new("kind", "smoke")]);
+    drop(_entered);
+    drop(span);
+    drop(guard);
+
+    let wait_result = tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if !trace_requests.lock().await.is_empty()
+                && !metric_requests.lock().await.is_empty()
+                && !log_requests.lock().await.is_empty()
+            {
+                break;
+            }
+
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await;
+
+    if wait_result.is_err() {
+        let trace_count = trace_requests.lock().await.len();
+        let metric_count = metric_requests.lock().await.len();
+        let log_count = log_requests.lock().await.len();
+
+        panic!(
+            "timed out waiting for starbase OTLP export (traces={trace_count}, metrics={metric_count}, logs={log_count})"
+        );
+    }
+
+    let log_requests = log_requests.lock().await.clone();
+    let trace_requests = trace_requests.lock().await.clone();
+    let metric_requests = metric_requests.lock().await.clone();
+    let service_names = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let metric_service_names = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let scope_names = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.scope_spans.iter())
+        .map(|scope| scope.scope.as_ref().map(|scope| scope.name.as_str()))
+        .collect::<Vec<_>>();
+    let spans = trace_requests
+        .iter()
+        .flat_map(|request| request.resource_spans.iter())
+        .flat_map(|resource| resource.scope_spans.iter())
+        .flat_map(|scope| scope.spans.iter())
+        .collect::<Vec<_>>();
+    let metric_names = metric_requests
+        .iter()
+        .flat_map(|request| request.resource_metrics.iter())
+        .flat_map(|resource| resource.scope_metrics.iter())
+        .flat_map(|scope| scope.metrics.iter())
+        .map(|metric| metric.name.as_str())
+        .collect::<Vec<_>>();
+    let log_bodies = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.scope_logs.iter())
+        .flat_map(|scope| scope.log_records.iter())
+        .filter_map(|record| record.body.as_ref())
+        .filter_map(|body| body.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+    let log_service_names = log_requests
+        .iter()
+        .flat_map(|request| request.resource_logs.iter())
+        .flat_map(|resource| resource.resource.as_ref())
+        .flat_map(|resource| resource.attributes.iter())
+        .filter(|attribute| attribute.key == "service.name")
+        .filter_map(|attribute| attribute.value.as_ref())
+        .filter_map(|value| value.value.as_ref())
+        .filter_map(|value| match value {
+            opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(value) => {
+                Some(value.as_str())
+            }
+            _ => None,
+        })
+        .collect::<Vec<_>>();
+
+    assert!(
+        spans.iter().any(|span| span.name == "otlp-test-span"),
+        "expected exported spans to include otlp-test-span"
+    );
+    assert!(
+        service_names.contains(&"starbase-test"),
+        "expected exported spans to include the configured service.name resource"
+    );
+    assert!(
+        metric_service_names.contains(&"starbase-test"),
+        "expected exported metrics to include the configured service.name resource"
+    );
+    assert!(
+        log_service_names.contains(&"starbase-test"),
+        "expected exported logs to include the configured service.name resource"
+    );
+    assert!(
+        scope_names.contains(&Some("starbase")),
+        "expected exported spans to use the starbase instrumentation scope"
+    );
+    assert!(
+        metric_names.contains(&"starbase.test.counter")
+            && metric_names.contains(&"starbase.test.duration"),
+        "expected exported metrics to include the test counter and histogram"
+    );
+    assert!(
+        log_bodies
+            .iter()
+            .any(|body| body.contains("hello from starbase")),
+        "expected exported OTLP logs to include the tracing event body"
+    );
+
+    let _ = shutdown_tx.send(());
+    server.await.unwrap();
+}


### PR DESCRIPTION
## Summary

Adds optional OpenTelemetry support to `starbase` application tracing.

This wires OTLP export for traces, metrics, and logs behind the existing tracing setup path, while keeping exporter setup best-effort and signal-specific. Applications can enable OTEL, opt into log export, and override the emitted `service.name`.

## Changes

- Add `otel` / `otlp` feature-gated tracing support.
- Export traces, metrics, and optional logs through OTLP.
- Add `OtelOptions` for enabling OTEL, logs, and service name configuration.
- Preserve normal tracing behavior when OTEL is disabled.
- Report setup/shutdown failures by signal instead of failing application startup.
- Document usage in the app README.
- Add an OTLP test collector covering trace, metric, and log export.

## Verification

- `cargo fmt --check`
- `cargo check -p starbase --no-default-features`
- `cargo test -p starbase --features otel otlp`