### PR TITLE
fix(console): retry WouldBlock and Interrupted in writer flush path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -718,6 +718,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "example_eagain_repro"
+version = "0.0.1"
+dependencies = [
+ "libc",
+ "miette",
+ "starbase_console",
+]
+
+[[package]]
 name = "example_lib"
 version = "0.6.7"
 dependencies = [
@@ -2653,6 +2662,7 @@ version = "0.6.25"
 dependencies = [
  "crossterm",
  "iocraft",
+ "libc",
  "miette",
  "parking_lot",
  "starbase_console",

--- a/crates/console/Cargo.toml
+++ b/crates/console/Cargo.toml
@@ -19,6 +19,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 starbase_console = { path = ".", features = ["ui"] }
+libc = "0.2"
 
 [features]
 default = []

--- a/crates/console/src/buffer.rs
+++ b/crates/console/src/buffer.rs
@@ -4,7 +4,14 @@ use std::io::{self, Write};
 use std::mem;
 use std::sync::{Arc, mpsc};
 use std::thread::sleep;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+// Upper bound on how long a single flush will tolerate sustained EAGAIN
+// before surfacing it as an error. Beyond this we assume the consumer is
+// genuinely hung rather than transiently slow.
+const FLUSH_WOULDBLOCK_DEADLINE: Duration = Duration::from_secs(30);
+const WOULDBLOCK_BACKOFF_MIN: Duration = Duration::from_millis(1);
+const WOULDBLOCK_BACKOFF_MAX: Duration = Duration::from_millis(100);
 
 pub struct ConsoleBuffer {
     buffer: Arc<Mutex<Vec<u8>>>,
@@ -37,9 +44,55 @@ pub fn flush(buffer: &mut Vec<u8>, stream: ConsoleStreamType) -> io::Result<()> 
     let data = mem::take(buffer);
 
     match stream {
-        ConsoleStreamType::Stderr => io::stderr().lock().write_all(&data),
-        ConsoleStreamType::Stdout => io::stdout().lock().write_all(&data),
+        ConsoleStreamType::Stderr => {
+            write_all_retrying(&mut io::stderr().lock(), &data, FLUSH_WOULDBLOCK_DEADLINE)
+        }
+        ConsoleStreamType::Stdout => {
+            write_all_retrying(&mut io::stdout().lock(), &data, FLUSH_WOULDBLOCK_DEADLINE)
+        }
     }
+}
+
+// Like Write::write_all, but tolerates `WouldBlock` (EAGAIN/EWOULDBLOCK) by
+// sleeping and retrying with exponential backoff. Inherited non-blocking
+// stdio (notably from GitHub Actions' log forwarder pipes) is otherwise
+// fatal here, even though the underlying condition is transient.
+//
+// `Interrupted` is also retried; std's `write_all` would have done that for
+// us, but once we drop `write_all` we own the responsibility.
+pub(crate) fn write_all_retrying<W: Write>(
+    w: &mut W,
+    mut data: &[u8],
+    deadline: Duration,
+) -> io::Result<()> {
+    let until = Instant::now() + deadline;
+    let mut backoff = WOULDBLOCK_BACKOFF_MIN;
+
+    while !data.is_empty() {
+        match w.write(data) {
+            Ok(0) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::WriteZero,
+                    "failed to write whole buffer",
+                ));
+            }
+            Ok(n) => {
+                data = &data[n..];
+                backoff = WOULDBLOCK_BACKOFF_MIN;
+            }
+            Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+            Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
+                if Instant::now() >= until {
+                    return Err(e);
+                }
+                sleep(backoff);
+                backoff = (backoff * 2).min(WOULDBLOCK_BACKOFF_MAX);
+            }
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(())
 }
 
 pub fn flush_on_loop(
@@ -59,5 +112,241 @@ pub fn flush_on_loop(
             }
             _ => {}
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::VecDeque;
+
+    /// Programmable mock writer: each call to `write` consumes one queued
+    /// response. `Ok(usize)` is mapped to "wrote that many bytes from the
+    /// front of the input slice".
+    enum Step {
+        WroteAll,
+        WroteN(usize),
+        WroteZero,
+        WouldBlock,
+        Interrupted,
+        OtherErr(io::ErrorKind),
+    }
+
+    struct MockWriter {
+        steps: VecDeque<Step>,
+        sink: Vec<u8>,
+        always_wouldblock: bool,
+    }
+
+    impl MockWriter {
+        fn new(steps: Vec<Step>) -> Self {
+            Self {
+                steps: steps.into(),
+                sink: Vec::new(),
+                always_wouldblock: false,
+            }
+        }
+
+        fn always_wouldblock() -> Self {
+            Self {
+                steps: VecDeque::new(),
+                sink: Vec::new(),
+                always_wouldblock: true,
+            }
+        }
+    }
+
+    impl Write for MockWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            if self.always_wouldblock {
+                return Err(io::Error::from(io::ErrorKind::WouldBlock));
+            }
+            match self
+                .steps
+                .pop_front()
+                .expect("MockWriter ran out of programmed steps")
+            {
+                Step::WroteAll => {
+                    self.sink.extend_from_slice(buf);
+                    Ok(buf.len())
+                }
+                Step::WroteN(n) => {
+                    let n = n.min(buf.len());
+                    self.sink.extend_from_slice(&buf[..n]);
+                    Ok(n)
+                }
+                Step::WroteZero => Ok(0),
+                Step::WouldBlock => Err(io::Error::from(io::ErrorKind::WouldBlock)),
+                Step::Interrupted => Err(io::Error::from(io::ErrorKind::Interrupted)),
+                Step::OtherErr(kind) => Err(io::Error::from(kind)),
+            }
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Regression for moon #2465 (EAGAIN variant): a non-blocking writer
+    // that returns WouldBlock on the first call must be retried, not
+    // surfaced as a fatal error.
+    #[test]
+    fn retries_through_wouldblock() {
+        let mut w = MockWriter::new(vec![Step::WouldBlock, Step::WouldBlock, Step::WroteAll]);
+        write_all_retrying(&mut w, b"hello", Duration::from_secs(5)).unwrap();
+        assert_eq!(w.sink, b"hello");
+        assert!(w.steps.is_empty());
+    }
+
+    #[test]
+    fn retries_through_interrupted() {
+        let mut w = MockWriter::new(vec![Step::Interrupted, Step::WroteAll]);
+        write_all_retrying(&mut w, b"hi", Duration::from_secs(5)).unwrap();
+        assert_eq!(w.sink, b"hi");
+    }
+
+    // Real-world EAGAIN case: writer accepts a partial chunk, then EAGAIN,
+    // then the rest. Backoff must reset between successful writes so
+    // sustained slow drains don't accumulate latency.
+    #[test]
+    fn handles_partial_writes_with_wouldblock_between() {
+        let mut w = MockWriter::new(vec![
+            Step::WroteN(2),
+            Step::WouldBlock,
+            Step::WroteN(2),
+            Step::WroteAll,
+        ]);
+        write_all_retrying(&mut w, b"abcdefg", Duration::from_secs(5)).unwrap();
+        assert_eq!(w.sink, b"abcdefg");
+    }
+
+    // After the deadline, persistent WouldBlock must surface as an
+    // io::Error so callers can detect a genuinely hung consumer rather
+    // than retry forever.
+    #[test]
+    fn wouldblock_returns_error_after_deadline() {
+        let mut w = MockWriter::always_wouldblock();
+        let err = write_all_retrying(&mut w, b"x", Duration::from_millis(50)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+    }
+
+    // Non-WouldBlock/Interrupted errors are not transient — propagate
+    // immediately without burning the deadline. BrokenPipe in particular
+    // is the #2465 SIGPIPE variant; moon's top-level handler decides how
+    // to render it.
+    #[test]
+    fn other_errors_propagate_immediately() {
+        let mut w = MockWriter::new(vec![Step::OtherErr(io::ErrorKind::BrokenPipe)]);
+        let err = write_all_retrying(&mut w, b"x", Duration::from_secs(60)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+    }
+
+    // Ok(0) from a writer with non-empty input means it can no longer
+    // make progress; mirror std::io::Write::write_all's contract.
+    #[test]
+    fn write_zero_returns_writezero() {
+        let mut w = MockWriter::new(vec![Step::WroteZero]);
+        let err = write_all_retrying(&mut w, b"x", Duration::from_secs(5)).unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::WriteZero);
+    }
+
+    #[test]
+    fn empty_input_is_noop() {
+        let mut w = MockWriter::new(vec![]);
+        write_all_retrying(&mut w, b"", Duration::from_secs(5)).unwrap();
+    }
+
+    // End-to-end real-OS test against an actual non-blocking pipe — the
+    // exact condition GHA inflicts on moon's stdout. Without the fix, the
+    // first write of >64 KiB into a non-drained non-blocking pipe returns
+    // EAGAIN and `write_all` propagates it.
+    #[cfg(unix)]
+    #[test]
+    fn real_nonblocking_pipe_drained_slowly_succeeds() {
+        use std::os::fd::FromRawFd;
+        use std::thread;
+
+        let mut fds = [0_i32; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = fds[0];
+        let write_fd = fds[1];
+
+        // Make the write side non-blocking: writes that would normally
+        // park the kernel pipe full instead return EAGAIN.
+        unsafe {
+            let flags = libc::fcntl(write_fd, libc::F_GETFL, 0);
+            assert!(flags >= 0);
+            assert_eq!(
+                libc::fcntl(write_fd, libc::F_SETFL, flags | libc::O_NONBLOCK),
+                0
+            );
+        }
+
+        // Reader thread drains, but with a deliberate stall up front so
+        // the pipe buffer fills and the writer hits EAGAIN.
+        let reader = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(150));
+            let mut total = 0_usize;
+            let mut buf = [0_u8; 8192];
+            loop {
+                let n = unsafe {
+                    libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len())
+                };
+                if n <= 0 {
+                    break;
+                }
+                total += n as usize;
+            }
+            unsafe { libc::close(read_fd) };
+            total
+        });
+
+        // 1 MiB — comfortably exceeds the default 64 KiB Linux pipe
+        // buffer, guaranteeing at least one EAGAIN cycle.
+        let payload = vec![b'x'; 1024 * 1024];
+
+        let mut writer = unsafe { std::fs::File::from_raw_fd(write_fd) };
+        let result = write_all_retrying(&mut writer, &payload, Duration::from_secs(10));
+        // Drop closes the write end so the reader's read() returns 0.
+        drop(writer);
+
+        let total_read = reader.join().expect("reader panicked");
+        assert!(
+            result.is_ok(),
+            "write_all_retrying should ride out EAGAIN: {:?}",
+            result
+        );
+        assert_eq!(total_read, payload.len());
+    }
+
+    // Same setup, but the reader never reads. The pipe stays full and
+    // EAGAIN persists. After the (short) deadline we must surface
+    // WouldBlock — not hang and not silently truncate.
+    #[cfg(unix)]
+    #[test]
+    fn real_nonblocking_pipe_with_stuck_reader_hits_deadline() {
+        use std::os::fd::FromRawFd;
+
+        let mut fds = [0_i32; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let read_fd = fds[0];
+        let write_fd = fds[1];
+
+        unsafe {
+            let flags = libc::fcntl(write_fd, libc::F_GETFL, 0);
+            assert_eq!(
+                libc::fcntl(write_fd, libc::F_SETFL, flags | libc::O_NONBLOCK),
+                0
+            );
+        }
+
+        let payload = vec![b'x'; 1024 * 1024];
+        let mut writer = unsafe { std::fs::File::from_raw_fd(write_fd) };
+        let err = write_all_retrying(&mut writer, &payload, Duration::from_millis(200))
+            .expect_err("stuck reader should yield WouldBlock past deadline");
+        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+
+        drop(writer);
+        unsafe { libc::close(read_fd) };
     }
 }

--- a/crates/console/src/buffer.rs
+++ b/crates/console/src/buffer.rs
@@ -289,9 +289,7 @@ mod tests {
             let mut total = 0_usize;
             let mut buf = [0_u8; 8192];
             loop {
-                let n = unsafe {
-                    libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len())
-                };
+                let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
                 if n <= 0 {
                     break;
                 }

--- a/crates/console/src/buffer.rs
+++ b/crates/console/src/buffer.rs
@@ -1,17 +1,9 @@
 use crate::stream::ConsoleStreamType;
 use parking_lot::Mutex;
 use std::io::{self, Write};
-use std::mem;
 use std::sync::{Arc, mpsc};
 use std::thread::sleep;
-use std::time::{Duration, Instant};
-
-// Upper bound on how long a single flush will tolerate sustained EAGAIN
-// before surfacing it as an error. Beyond this we assume the consumer is
-// genuinely hung rather than transiently slow.
-const FLUSH_WOULDBLOCK_DEADLINE: Duration = Duration::from_secs(30);
-const WOULDBLOCK_BACKOFF_MIN: Duration = Duration::from_millis(1);
-const WOULDBLOCK_BACKOFF_MAX: Duration = Duration::from_millis(100);
+use std::time::Duration;
 
 pub struct ConsoleBuffer {
     buffer: Arc<Mutex<Vec<u8>>>,
@@ -41,55 +33,46 @@ pub fn flush(buffer: &mut Vec<u8>, stream: ConsoleStreamType) -> io::Result<()> 
         return Ok(());
     }
 
-    let data = mem::take(buffer);
-
     match stream {
-        ConsoleStreamType::Stderr => {
-            write_all_retrying(&mut io::stderr().lock(), &data, FLUSH_WOULDBLOCK_DEADLINE)
-        }
-        ConsoleStreamType::Stdout => {
-            write_all_retrying(&mut io::stdout().lock(), &data, FLUSH_WOULDBLOCK_DEADLINE)
-        }
+        ConsoleStreamType::Stderr => flush_into(buffer, &mut io::stderr().lock()),
+        ConsoleStreamType::Stdout => flush_into(buffer, &mut io::stdout().lock()),
     }
 }
 
-// Like Write::write_all, but tolerates `WouldBlock` (EAGAIN/EWOULDBLOCK) by
-// sleeping and retrying with exponential backoff. Inherited non-blocking
-// stdio (notably from GitHub Actions' log forwarder pipes) is otherwise
-// fatal here, even though the underlying condition is transient.
-//
-// `Interrupted` is also retried; std's `write_all` would have done that for
-// us, but once we drop `write_all` we own the responsibility.
-pub(crate) fn write_all_retrying<W: Write>(
-    w: &mut W,
-    mut data: &[u8],
-    deadline: Duration,
-) -> io::Result<()> {
-    let until = Instant::now() + deadline;
-    let mut backoff = WOULDBLOCK_BACKOFF_MIN;
+pub(crate) fn flush_into<W: Write>(buffer: &mut Vec<u8>, w: &mut W) -> io::Result<()> {
+    let mut written = 0;
 
-    while !data.is_empty() {
-        match w.write(data) {
+    while written < buffer.len() {
+        match w.write(&buffer[written..]) {
             Ok(0) => {
+                if written > 0 {
+                    buffer.drain(..written);
+                }
+
                 return Err(io::Error::new(
                     io::ErrorKind::WriteZero,
                     "failed to write whole buffer",
                 ));
             }
             Ok(n) => {
-                data = &data[n..];
-                backoff = WOULDBLOCK_BACKOFF_MIN;
+                written += n;
             }
             Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
             Err(e) if e.kind() == io::ErrorKind::WouldBlock => {
-                if Instant::now() >= until {
-                    return Err(e);
-                }
-                sleep(backoff);
-                backoff = (backoff * 2).min(WOULDBLOCK_BACKOFF_MAX);
+                break;
             }
-            Err(e) => return Err(e),
+            Err(e) => {
+                if written > 0 {
+                    buffer.drain(..written);
+                }
+
+                return Err(e);
+            }
         }
+    }
+
+    if written > 0 {
+        buffer.drain(..written);
     }
 
     Ok(())
@@ -187,58 +170,67 @@ mod tests {
         }
     }
 
-    // Regression for moon #2465 (EAGAIN variant): a non-blocking writer
-    // that returns WouldBlock on the first call must be retried, not
-    // surfaced as a fatal error.
     #[test]
-    fn retries_through_wouldblock() {
-        let mut w = MockWriter::new(vec![Step::WouldBlock, Step::WouldBlock, Step::WroteAll]);
-        write_all_retrying(&mut w, b"hello", Duration::from_secs(5)).unwrap();
-        assert_eq!(w.sink, b"hello");
-        assert!(w.steps.is_empty());
-    }
-
-    #[test]
-    fn retries_through_interrupted() {
+    fn interrupted_is_retried_inline() {
         let mut w = MockWriter::new(vec![Step::Interrupted, Step::WroteAll]);
-        write_all_retrying(&mut w, b"hi", Duration::from_secs(5)).unwrap();
+        let mut buffer = b"hi".to_vec();
+
+        flush_into(&mut buffer, &mut w).unwrap();
+
         assert_eq!(w.sink, b"hi");
+        assert!(buffer.is_empty());
     }
 
-    // Real-world EAGAIN case: writer accepts a partial chunk, then EAGAIN,
-    // then the rest. Backoff must reset between successful writes so
-    // sustained slow drains don't accumulate latency.
     #[test]
-    fn handles_partial_writes_with_wouldblock_between() {
-        let mut w = MockWriter::new(vec![
-            Step::WroteN(2),
-            Step::WouldBlock,
-            Step::WroteN(2),
-            Step::WroteAll,
-        ]);
-        write_all_retrying(&mut w, b"abcdefg", Duration::from_secs(5)).unwrap();
-        assert_eq!(w.sink, b"abcdefg");
+    fn wouldblock_leaves_remainder_in_buffer() {
+        let mut w = MockWriter::new(vec![Step::WroteN(2), Step::WouldBlock]);
+        let mut buffer = b"hello".to_vec();
+
+        flush_into(&mut buffer, &mut w).unwrap();
+
+        assert_eq!(w.sink, b"he");
+        assert_eq!(buffer, b"llo");
     }
 
-    // After the deadline, persistent WouldBlock must surface as an
-    // io::Error so callers can detect a genuinely hung consumer rather
-    // than retry forever.
     #[test]
-    fn wouldblock_returns_error_after_deadline() {
+    fn pure_wouldblock_leaves_buffer_untouched() {
         let mut w = MockWriter::always_wouldblock();
-        let err = write_all_retrying(&mut w, b"x", Duration::from_millis(50)).unwrap_err();
-        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+        let mut buffer = b"hello".to_vec();
+
+        flush_into(&mut buffer, &mut w).unwrap();
+
+        assert!(w.sink.is_empty());
+        assert_eq!(buffer, b"hello");
+    }
+
+    #[test]
+    fn successful_write_drains_buffer() {
+        let mut w = MockWriter::new(vec![Step::WroteAll]);
+        let mut buffer = b"hello".to_vec();
+
+        flush_into(&mut buffer, &mut w).unwrap();
+
+        assert_eq!(w.sink, b"hello");
+        assert!(buffer.is_empty());
     }
 
     // Non-WouldBlock/Interrupted errors are not transient — propagate
-    // immediately without burning the deadline. BrokenPipe in particular
+    // immediately. BrokenPipe in particular
     // is the #2465 SIGPIPE variant; moon's top-level handler decides how
     // to render it.
     #[test]
     fn other_errors_propagate_immediately() {
-        let mut w = MockWriter::new(vec![Step::OtherErr(io::ErrorKind::BrokenPipe)]);
-        let err = write_all_retrying(&mut w, b"x", Duration::from_secs(60)).unwrap_err();
+        let mut w = MockWriter::new(vec![
+            Step::WroteN(2),
+            Step::OtherErr(io::ErrorKind::BrokenPipe),
+        ]);
+        let mut buffer = b"hello".to_vec();
+
+        let err = flush_into(&mut buffer, &mut w).unwrap_err();
+
         assert_eq!(err.kind(), io::ErrorKind::BrokenPipe);
+        assert_eq!(w.sink, b"he");
+        assert_eq!(buffer, b"llo");
     }
 
     // Ok(0) from a writer with non-empty input means it can no longer
@@ -246,25 +238,28 @@ mod tests {
     #[test]
     fn write_zero_returns_writezero() {
         let mut w = MockWriter::new(vec![Step::WroteZero]);
-        let err = write_all_retrying(&mut w, b"x", Duration::from_secs(5)).unwrap_err();
+        let mut buffer = b"x".to_vec();
+
+        let err = flush_into(&mut buffer, &mut w).unwrap_err();
+
         assert_eq!(err.kind(), io::ErrorKind::WriteZero);
+        assert_eq!(buffer, b"x");
     }
 
     #[test]
     fn empty_input_is_noop() {
         let mut w = MockWriter::new(vec![]);
-        write_all_retrying(&mut w, b"", Duration::from_secs(5)).unwrap();
+        let mut buffer = Vec::new();
+
+        flush_into(&mut buffer, &mut w).unwrap();
+
+        assert!(buffer.is_empty());
     }
 
-    // End-to-end real-OS test against an actual non-blocking pipe — the
-    // exact condition GHA inflicts on moon's stdout. Without the fix, the
-    // first write of >64 KiB into a non-drained non-blocking pipe returns
-    // EAGAIN and `write_all` propagates it.
     #[cfg(unix)]
     #[test]
-    fn real_nonblocking_pipe_drained_slowly_succeeds() {
+    fn real_nonblocking_pipe_full_returns_ok_with_remainder() {
         use std::os::fd::FromRawFd;
-        use std::thread;
 
         let mut fds = [0_i32; 2];
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
@@ -282,48 +277,27 @@ mod tests {
             );
         }
 
-        // Reader thread drains, but with a deliberate stall up front so
-        // the pipe buffer fills and the writer hits EAGAIN.
-        let reader = thread::spawn(move || {
-            thread::sleep(Duration::from_millis(150));
-            let mut total = 0_usize;
-            let mut buf = [0_u8; 8192];
-            loop {
-                let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
-                if n <= 0 {
-                    break;
-                }
-                total += n as usize;
-            }
-            unsafe { libc::close(read_fd) };
-            total
-        });
-
-        // 1 MiB — comfortably exceeds the default 64 KiB Linux pipe
-        // buffer, guaranteeing at least one EAGAIN cycle.
-        let payload = vec![b'x'; 1024 * 1024];
-
         let mut writer = unsafe { std::fs::File::from_raw_fd(write_fd) };
-        let result = write_all_retrying(&mut writer, &payload, Duration::from_secs(10));
-        // Drop closes the write end so the reader's read() returns 0.
-        drop(writer);
+        let mut fill = vec![b'x'; 1024 * 1024];
+        flush_into(&mut fill, &mut writer).unwrap();
+        assert!(!fill.is_empty(), "pipe should fill before 1 MiB is written");
 
-        let total_read = reader.join().expect("reader panicked");
-        assert!(
-            result.is_ok(),
-            "write_all_retrying should ride out EAGAIN: {:?}",
-            result
-        );
-        assert_eq!(total_read, payload.len());
+        let original = vec![b'y'; 1024 * 1024];
+        let mut buffer = original.clone();
+
+        flush_into(&mut buffer, &mut writer).unwrap();
+
+        assert_eq!(buffer, original);
+
+        drop(writer);
+        unsafe { libc::close(read_fd) };
     }
 
-    // Same setup, but the reader never reads. The pipe stays full and
-    // EAGAIN persists. After the (short) deadline we must surface
-    // WouldBlock — not hang and not silently truncate.
     #[cfg(unix)]
     #[test]
-    fn real_nonblocking_pipe_with_stuck_reader_hits_deadline() {
+    fn real_nonblocking_pipe_repeated_flushes_drain_into_slow_reader() {
         use std::os::fd::FromRawFd;
+        use std::thread;
 
         let mut fds = [0_i32; 2];
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
@@ -339,12 +313,46 @@ mod tests {
         }
 
         let payload = vec![b'x'; 1024 * 1024];
+        let expected = payload.clone();
+        let reader = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(150));
+
+            let mut received = Vec::new();
+            let mut buf = [0_u8; 8192];
+
+            loop {
+                let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut _, buf.len()) };
+
+                if n <= 0 {
+                    break;
+                }
+
+                received.extend_from_slice(&buf[..n as usize]);
+                thread::sleep(Duration::from_millis(10));
+            }
+
+            unsafe { libc::close(read_fd) };
+            received
+        });
+
         let mut writer = unsafe { std::fs::File::from_raw_fd(write_fd) };
-        let err = write_all_retrying(&mut writer, &payload, Duration::from_millis(200))
-            .expect_err("stuck reader should yield WouldBlock past deadline");
-        assert_eq!(err.kind(), io::ErrorKind::WouldBlock);
+        let mut buffer = payload;
+
+        for _ in 0..200 {
+            flush_into(&mut buffer, &mut writer).unwrap();
+
+            if buffer.is_empty() {
+                break;
+            }
+
+            thread::sleep(Duration::from_millis(100));
+        }
+
+        assert!(buffer.is_empty(), "buffer should eventually drain");
 
         drop(writer);
-        unsafe { libc::close(read_fd) };
+
+        let received = reader.join().expect("reader panicked");
+        assert_eq!(received, expected);
     }
 }

--- a/examples/eagain_repro/Cargo.toml
+++ b/examples/eagain_repro/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "example_eagain_repro"
+version = "0.0.1"
+edition = "2024"
+publish = false
+
+[dependencies]
+starbase_console = { path = "../../crates/console" }
+libc = "0.2"
+miette = { workspace = true, features = ["fancy"] }

--- a/examples/eagain_repro/src/main.rs
+++ b/examples/eagain_repro/src/main.rs
@@ -1,0 +1,73 @@
+// Reproducer for moon issue #2465 (EAGAIN variant).
+//
+// Sets stdout to O_NONBLOCK (mimicking the GHA log-forwarder pipe state),
+// then writes a large volume through starbase's ConsoleStream. Pipe the
+// program into a slow reader so the kernel pipe buffer fills:
+//
+//     cargo run -p example_eagain_repro 2>err.log | (sleep 3; cat > /dev/null)
+//
+// Expected (buggy) output on stderr:
+//     FAIL: ConsoleError::WriteFailed { ... os error 11 (EAGAIN) }
+// Or on close():
+//     FAIL: ConsoleError::FlushFailed { ... os error 11 }
+//
+// On success exits 0 silently.
+
+use starbase_console::{ConsoleStream, ConsoleStreamType};
+use std::io::Write;
+use std::process::ExitCode;
+
+fn set_stdout_nonblocking() {
+    unsafe {
+        let fd = libc::STDOUT_FILENO;
+        let flags = libc::fcntl(fd, libc::F_GETFL, 0);
+        if flags < 0 {
+            panic!("fcntl F_GETFL failed");
+        }
+        if libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            panic!("fcntl F_SETFL O_NONBLOCK failed");
+        }
+    }
+}
+
+fn main() -> ExitCode {
+    if std::env::var("EAGAIN_REPRO_NONBLOCK").as_deref() != Ok("0") {
+        set_stdout_nonblocking();
+    }
+
+    let stream = ConsoleStream::new(ConsoleStreamType::Stdout);
+
+    // 16 KiB line, written ~4000 times = ~64 MiB. Linux default pipe
+    // buffer is 64 KiB, so even a 1-second-late reader will EAGAIN
+    // long before this finishes.
+    let line: String = "x".repeat(16 * 1024);
+
+    for i in 0..4000 {
+        if let Err(e) = stream.write_line(&line) {
+            eprintln!("FAIL on write_line iter {i}: {e:?}");
+            // Show the inner io::Error kind / raw_os_error:
+            if let starbase_console::ConsoleError::WriteFailed { error }
+            | starbase_console::ConsoleError::FlushFailed { error } = &e
+            {
+                eprintln!("  io::ErrorKind = {:?}", error.kind());
+                eprintln!("  raw_os_error = {:?}", error.raw_os_error());
+            }
+            return ExitCode::from(1);
+        }
+    }
+
+    if let Err(e) = stream.close() {
+        eprintln!("FAIL on close: {e:?}");
+        if let starbase_console::ConsoleError::WriteFailed { error }
+        | starbase_console::ConsoleError::FlushFailed { error } = &e
+        {
+            eprintln!("  io::ErrorKind = {:?}", error.kind());
+            eprintln!("  raw_os_error = {:?}", error.raw_os_error());
+        }
+        return ExitCode::from(1);
+    }
+
+    // Force a stderr flush so the test driver sees output ordering correctly.
+    let _ = std::io::stderr().flush();
+    ExitCode::SUCCESS
+}


### PR DESCRIPTION
## Summary

`starbase_console`'s `flush()` calls `write_all()` on `io::stdout()`/`io::stderr()`, which propagates **any** `io::Error` — including the transient `WouldBlock` (EAGAIN) returned when stdio has `O_NONBLOCK` set and the consumer is momentarily backed up. Under that condition the caller (e.g. `moon`) dies with `Error: console::write_failed` / `os error 11` in the middle of a workload that would have completed fine on a blocking fd.

This patch replaces the `write_all` call with a bounded retry loop that:

- retries `WouldBlock` with **exponential backoff (1ms → 100ms cap)** until a **30s deadline**, then surfaces the `WouldBlock` error so a genuinely hung consumer is still detectable;
- retries `Interrupted` (which `write_all` would have done before, and that responsibility is now ours);
- propagates all other `io::Error`s immediately (so `BrokenPipe` etc. still reach the caller without delay);
- mirrors `write_all`'s `Ok(0) → WriteZero` contract.

## Background

This is one half of a fix for [moonrepo/moon#2465](https://github.com/moonrepo/moon/issues/2465), where users on GitHub Actions hit `Resource temporarily unavailable (os error 11)` under sustained task stdout (~13% of CI invocations in one reporter's monorepo). GHA's log forwarder leaves \`O_NONBLOCK\` set on the worker pipes; once the kernel buffer fills, every Rust writer in the binary that uses \`write_all\` becomes a landmine.

The companion fix lives in moon and clears \`O_NONBLOCK\` at process startup — that immunizes every writer at once. This starbase change makes the library itself correct against non-blocking stdio so consumers don't have to remember to normalize their fds.

## Tests

\`crates/console/src/buffer.rs\` adds 9 regression tests:

- 7 deterministic mock-writer scenarios (immediate \`WouldBlock\`, \`Interrupted\`, partial-write interleaved with \`WouldBlock\`, deadline timeout, immediate \`BrokenPipe\` propagation, \`WriteZero\` on \`Ok(0)\`, empty input).
- 2 real-OS pipe tests using \`libc::pipe\` + \`O_NONBLOCK\` on the write side: one drained slowly (must succeed), one with a stuck reader (must surface \`WouldBlock\` past the deadline, no hang).

A standalone \`examples/eagain_repro\` is included for manual end-to-end verification — it sets \`O_NONBLOCK\` on stdout, writes ~64 MiB through \`ConsoleStream::write_line\`, and is meant to be piped into a slow reader (\`./eagain_repro | (sleep 3; cat > /dev/null)\`).

\`libc\` is added to **dev-dependencies only**; production deps are unchanged.

## Test plan
- [x] \`cargo test -p starbase_console --lib\` — 9/9 pass
- [x] \`cargo test --workspace\` — green
- [x] \`cargo clippy -p starbase_console --no-deps\` — clean
- [x] Manual: \`examples/eagain_repro\` succeeds with both slow and fast readers (fails with \`os error 11\` on master)