### PR TITLE
feat: add `starbase_process` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3059,6 +3059,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "starbase_process"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "thiserror",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "starbase_sandbox"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ dirs = "6.0.0"
 hex = "0.4.3"
 iocraft = "0.8.4"
 # iocraft = { git = "https://github.com/ccbrown/iocraft", branch = "main" }
+libc = "0.2.180"
 miette = "7.6.0"
 regex = { version = "1.13.1", default-features = false }
 relative-path = "2.0.1"
@@ -35,3 +36,4 @@ tokio = { version = "1.53.1", default-features = false, features = [
     "sync",
 ] }
 tracing = { version = "0.1.44" }
+windows-sys = { version = "0.61.2", default-features = false }

--- a/README.md
+++ b/README.md
@@ -22,5 +22,7 @@ A starbase is built with the following modules:
   [`starbase_styles`](https://crates.io/crates/starbase_styles).
 - **Operations drive** - Shell detection and profile management with
   [`starbase_shell`](https://crates.io/crates/starbase_shell).
+- **Thruster control** - Bounded child process execution with
+  [`starbase_process`](https://crates.io/crates/starbase_process).
 - **Cargo hold** - Archive packing and unpacking with
   [`starbase_archive`](https://crates.io/crates/starbase_archive).

--- a/crates/process/Cargo.toml
+++ b/crates/process/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "starbase_process"
+version = "0.1.0"
+edition = "2024"
+license = "MIT"
+description = "Utilities for executing and managing child processes."
+repository = "https://github.com/moonrepo/starbase"
+rust-version = "1.89.0"
+
+[dependencies]
+thiserror = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = [
+	"Win32_Foundation",
+	"Win32_Security",
+	"Win32_System_JobObjects",
+	"Win32_System_Threading",
+] }

--- a/crates/process/README.md
+++ b/crates/process/README.md
@@ -1,0 +1,6 @@
+# starbase_process
+
+![Crates.io](https://img.shields.io/crates/v/starbase_process)
+![Crates.io](https://img.shields.io/crates/d/starbase_process)
+
+Utilities for bounded child process execution and process-tree cleanup.

--- a/crates/process/src/capture.rs
+++ b/crates/process/src/capture.rs
@@ -1,0 +1,590 @@
+use crate::CaptureError;
+use std::fs::File;
+use std::io::{self, Read, Write};
+use std::process::{Child, Command, ExitStatus, Stdio};
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+use std::thread;
+use std::time::{Duration, Instant};
+
+/// Configuration for capturing a command with the blocking executor.
+#[derive(Clone, Debug, Default)]
+pub struct CaptureOptions {
+    /// Kill the command if it runs longer than this duration.
+    pub timeout: Option<Duration>,
+
+    /// Maximum combined number of bytes captured from stdout and stderr.
+    pub output_limit: Option<usize>,
+}
+
+/// Output captured in memory.
+#[derive(Debug)]
+pub struct Output {
+    pub status: ExitStatus,
+    pub stderr: Vec<u8>,
+    pub stdout: Vec<u8>,
+}
+
+/// Metadata for output captured in caller-owned files.
+#[derive(Debug)]
+pub struct FileOutput {
+    pub status: ExitStatus,
+    pub stderr_len: u64,
+    pub stdout_len: u64,
+}
+
+/// Execute a command synchronously and capture byte-safe output in memory.
+///
+/// Any descendants still running after capture completes are terminated. Set a timeout when a
+/// descendant may keep an output pipe open, as capture otherwise waits for all output readers.
+pub fn capture_output(
+    command: &mut Command,
+    input: Option<Vec<u8>>,
+    options: &CaptureOptions,
+) -> Result<Output, CaptureError> {
+    let output = BlockingCapture::spawn(
+        command,
+        input,
+        options,
+        CaptureTarget::Memory,
+        CaptureTarget::Memory,
+    )?
+    .wait()?;
+
+    Ok(Output {
+        status: output.status,
+        stderr: output.stderr.into_memory(),
+        stdout: output.stdout.into_memory(),
+    })
+}
+
+/// Execute a command synchronously and capture output in caller-owned files.
+///
+/// Any descendants still running after capture completes are terminated. Set a timeout when a
+/// descendant may keep an output pipe open, as capture otherwise waits for all output readers.
+pub fn capture_output_to_files(
+    command: &mut Command,
+    input: Option<Vec<u8>>,
+    options: &CaptureOptions,
+    stdout: File,
+    stderr: File,
+) -> Result<FileOutput, CaptureError> {
+    let output = BlockingCapture::spawn(
+        command,
+        input,
+        options,
+        CaptureTarget::File(stdout),
+        CaptureTarget::File(stderr),
+    )?
+    .wait()?;
+
+    Ok(FileOutput {
+        status: output.status,
+        stderr_len: output.stderr.into_file_len(),
+        stdout_len: output.stdout.into_file_len(),
+    })
+}
+
+enum CaptureTarget {
+    File(File),
+    Memory,
+}
+
+enum CapturedOutput {
+    File(u64),
+    Memory(Vec<u8>),
+}
+
+impl CapturedOutput {
+    fn into_file_len(self) -> u64 {
+        match self {
+            Self::File(len) => len,
+            Self::Memory(_) => unreachable!("output was not captured to a file"),
+        }
+    }
+
+    fn into_memory(self) -> Vec<u8> {
+        match self {
+            Self::File(_) => unreachable!("output was not captured to memory"),
+            Self::Memory(output) => output,
+        }
+    }
+}
+
+struct CaptureOutput {
+    status: ExitStatus,
+    stderr: CapturedOutput,
+    stdout: CapturedOutput,
+}
+
+type ReaderHandle = thread::JoinHandle<io::Result<CapturedOutput>>;
+type WriterHandle = thread::JoinHandle<io::Result<()>>;
+
+struct BlockingCapture {
+    child: ChildGuard,
+    deadline: Option<Instant>,
+    exceeded: Arc<AtomicBool>,
+    output_limit: Option<usize>,
+    stderr_reader: Option<ReaderHandle>,
+    stdin_writer: Option<WriterHandle>,
+    stdout_reader: Option<ReaderHandle>,
+    timeout: Option<Duration>,
+}
+
+impl BlockingCapture {
+    fn spawn(
+        command: &mut Command,
+        input: Option<Vec<u8>>,
+        options: &CaptureOptions,
+        stdout_target: CaptureTarget,
+        stderr_target: CaptureTarget,
+    ) -> Result<Self, CaptureError> {
+        let deadline = options
+            .timeout
+            .map(|timeout| {
+                Instant::now()
+                    .checked_add(timeout)
+                    .ok_or_else(|| capture_error("process timeout is too large"))
+            })
+            .transpose()?;
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            command.process_group(0);
+        }
+
+        if input.is_some() {
+            command.stdin(Stdio::piped());
+        } else {
+            command.stdin(Stdio::null());
+        }
+
+        command.stdout(Stdio::piped()).stderr(Stdio::piped());
+
+        let child = command.spawn().map_err(CaptureError::Capture)?;
+        let mut child = ChildGuard::new(child).map_err(CaptureError::Capture)?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| capture_error("process stdout was not piped"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| capture_error("process stderr was not piped"))?;
+        let exceeded = Arc::new(AtomicBool::new(false));
+        let output_size = Arc::new(AtomicUsize::new(0));
+        let stdout_reader = read_bounded_output(
+            stdout,
+            stdout_target,
+            options.output_limit,
+            Arc::clone(&output_size),
+            Arc::clone(&exceeded),
+        );
+        let stderr_reader = read_bounded_output(
+            stderr,
+            stderr_target,
+            options.output_limit,
+            Arc::clone(&output_size),
+            Arc::clone(&exceeded),
+        );
+        let stdin_writer = input.and_then(|input| {
+            child.stdin.take().map(|mut stdin| {
+                thread::spawn(move || match stdin.write_all(&input) {
+                    Err(error) if error.kind() != io::ErrorKind::BrokenPipe => Err(error),
+                    _ => Ok(()),
+                })
+            })
+        });
+
+        Ok(Self {
+            child,
+            deadline,
+            exceeded,
+            output_limit: options.output_limit,
+            stderr_reader: Some(stderr_reader),
+            stdin_writer,
+            stdout_reader: Some(stdout_reader),
+            timeout: options.timeout,
+        })
+    }
+
+    fn wait(mut self) -> Result<CaptureOutput, CaptureError> {
+        let mut status = None;
+
+        loop {
+            if self.exceeded.load(Ordering::Acquire) {
+                return self.abort(CaptureError::OutputLimitExceeded {
+                    limit: self.output_limit.unwrap_or_default(),
+                });
+            }
+
+            if status.is_none() {
+                match self.child.try_wait() {
+                    Ok(exit_status) => status = exit_status,
+                    Err(error) => return self.abort(CaptureError::Capture(error)),
+                }
+            }
+
+            let stdin_finished = self
+                .stdin_writer
+                .as_ref()
+                .is_none_or(thread::JoinHandle::is_finished);
+
+            if status.is_some()
+                && stdin_finished
+                && self
+                    .stdout_reader
+                    .as_ref()
+                    .is_some_and(|reader| reader.is_finished())
+                && self
+                    .stderr_reader
+                    .as_ref()
+                    .is_some_and(|reader| reader.is_finished())
+            {
+                break;
+            }
+
+            if self
+                .deadline
+                .is_some_and(|deadline| Instant::now() >= deadline)
+            {
+                return self.abort(CaptureError::Timeout {
+                    timeout: self.timeout.unwrap_or_default(),
+                });
+            }
+
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        let stdout = self.join_stdout()?;
+        let stderr = self.join_stderr()?;
+        self.join_stdin()?;
+
+        if self.exceeded.load(Ordering::Acquire) {
+            return self.abort(CaptureError::OutputLimitExceeded {
+                limit: self.output_limit.unwrap_or_default(),
+            });
+        }
+
+        let output = CaptureOutput {
+            status: status.expect("completed process has an exit status"),
+            stdout,
+            stderr,
+        };
+
+        self.child.finish();
+
+        Ok(output)
+    }
+
+    fn abort<T>(&mut self, error: CaptureError) -> Result<T, CaptureError> {
+        self.child.terminate();
+        self.discard_workers();
+
+        Err(error)
+    }
+
+    fn discard_workers(&mut self) {
+        if let Some(reader) = self.stdout_reader.take() {
+            discard_worker(reader);
+        }
+
+        if let Some(reader) = self.stderr_reader.take() {
+            discard_worker(reader);
+        }
+
+        if let Some(writer) = self.stdin_writer.take() {
+            discard_worker(writer);
+        }
+    }
+
+    fn join_stdout(&mut self) -> Result<CapturedOutput, CaptureError> {
+        let reader = self
+            .stdout_reader
+            .take()
+            .expect("stdout reader has not been joined");
+
+        match join_reader(reader) {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                self.child.terminate();
+                self.discard_workers();
+                Err(error)
+            }
+        }
+    }
+
+    fn join_stderr(&mut self) -> Result<CapturedOutput, CaptureError> {
+        let reader = self
+            .stderr_reader
+            .take()
+            .expect("stderr reader has not been joined");
+
+        match join_reader(reader) {
+            Ok(output) => Ok(output),
+            Err(error) => {
+                self.child.terminate();
+                self.discard_workers();
+                Err(error)
+            }
+        }
+    }
+
+    fn join_stdin(&mut self) -> Result<(), CaptureError> {
+        let Some(writer) = self.stdin_writer.take() else {
+            return Ok(());
+        };
+
+        match join_writer(writer) {
+            Ok(()) => Ok(()),
+            Err(error) => {
+                self.child.terminate();
+                self.discard_workers();
+                Err(error)
+            }
+        }
+    }
+}
+
+struct ChildGuard {
+    child: Child,
+    armed: bool,
+    #[cfg(windows)]
+    job: JobObject,
+}
+
+impl ChildGuard {
+    fn new(child: Child) -> io::Result<Self> {
+        #[cfg(windows)]
+        let job = match JobObject::assign(&child) {
+            Ok(job) => job,
+            Err(error) => {
+                let mut child = child;
+                let _ = child.kill();
+                let _ = child.wait();
+
+                return Err(error);
+            }
+        };
+
+        Ok(Self {
+            child,
+            armed: true,
+            #[cfg(windows)]
+            job,
+        })
+    }
+
+    fn finish(&mut self) {
+        #[cfg(unix)]
+        terminate_process_group(&self.child);
+
+        self.armed = false;
+    }
+
+    fn terminate(&mut self) {
+        if self.armed {
+            #[cfg(unix)]
+            terminate_process_group(&self.child);
+
+            #[cfg(windows)]
+            self.job.terminate();
+
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+            self.armed = false;
+        }
+    }
+}
+
+impl std::ops::Deref for ChildGuard {
+    type Target = Child;
+
+    fn deref(&self) -> &Self::Target {
+        &self.child
+    }
+}
+
+impl std::ops::DerefMut for ChildGuard {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.child
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        self.terminate();
+    }
+}
+
+fn capture_error(message: &str) -> CaptureError {
+    CaptureError::Capture(io::Error::other(message))
+}
+
+fn read_bounded_output<R: Read + Send + 'static>(
+    mut reader: R,
+    target: CaptureTarget,
+    limit: Option<usize>,
+    output_size: Arc<AtomicUsize>,
+    exceeded: Arc<AtomicBool>,
+) -> ReaderHandle {
+    thread::spawn(move || {
+        let mut output = match target {
+            CaptureTarget::File(file) => OutputWriter::File(file),
+            CaptureTarget::Memory => OutputWriter::Memory(Vec::new()),
+        };
+        let mut buffer = [0; 16 * 1024];
+        let mut output_len = 0u64;
+
+        loop {
+            let read = reader.read(&mut buffer)?;
+
+            if read == 0 {
+                break;
+            }
+
+            if let Some(limit) = limit {
+                let previous_size = output_size
+                    .fetch_update(Ordering::AcqRel, Ordering::Acquire, |size| {
+                        Some(size.saturating_add(read))
+                    })
+                    .unwrap_or(usize::MAX);
+
+                if previous_size.saturating_add(read) > limit {
+                    exceeded.store(true, Ordering::Release);
+                    continue;
+                }
+            }
+
+            output.write_all(&buffer[..read])?;
+            output_len = output_len.saturating_add(read as u64);
+        }
+
+        Ok(match output {
+            OutputWriter::File(_) => CapturedOutput::File(output_len),
+            OutputWriter::Memory(output) => CapturedOutput::Memory(output),
+        })
+    })
+}
+
+enum OutputWriter {
+    File(File),
+    Memory(Vec<u8>),
+}
+
+impl Write for OutputWriter {
+    fn write(&mut self, buffer: &[u8]) -> io::Result<usize> {
+        match self {
+            Self::File(file) => file.write(buffer),
+            Self::Memory(output) => output.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            Self::File(file) => file.flush(),
+            Self::Memory(output) => output.flush(),
+        }
+    }
+}
+
+#[cfg(unix)]
+fn terminate_process_group(child: &Child) {
+    if let Ok(pid) = i32::try_from(child.id()) {
+        unsafe {
+            libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+}
+
+#[cfg(windows)]
+struct JobObject(windows_sys::Win32::Foundation::HANDLE);
+
+#[cfg(windows)]
+impl JobObject {
+    fn assign(child: &Child) -> io::Result<Self> {
+        use std::os::windows::io::AsRawHandle;
+        use windows_sys::Win32::{
+            Foundation::HANDLE,
+            System::JobObjects::{
+                AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+                JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+                SetInformationJobObject,
+            },
+        };
+
+        let handle = unsafe { CreateJobObjectW(std::ptr::null(), std::ptr::null()) };
+
+        if handle.is_null() {
+            return Err(io::Error::last_os_error());
+        }
+
+        let job = Self(handle);
+        let mut limits = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+        limits.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+        let configured = unsafe {
+            SetInformationJobObject(
+                job.0,
+                JobObjectExtendedLimitInformation,
+                std::ptr::from_ref(&limits).cast(),
+                std::mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
+            )
+        };
+
+        if configured == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        let process = child.as_raw_handle() as HANDLE;
+        let assigned = unsafe { AssignProcessToJobObject(job.0, process) };
+
+        if assigned == 0 {
+            return Err(io::Error::last_os_error());
+        }
+
+        Ok(job)
+    }
+
+    fn terminate(&self) {
+        unsafe {
+            windows_sys::Win32::System::JobObjects::TerminateJobObject(self.0, 1);
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for JobObject {
+    fn drop(&mut self) {
+        unsafe {
+            windows_sys::Win32::Foundation::CloseHandle(self.0);
+        }
+    }
+}
+
+fn discard_worker<T>(worker: thread::JoinHandle<io::Result<T>>) {
+    for _ in 0..10 {
+        if worker.is_finished() {
+            let _ = worker.join();
+            return;
+        }
+
+        thread::sleep(Duration::from_millis(10));
+    }
+}
+
+fn join_reader(reader: ReaderHandle) -> Result<CapturedOutput, CaptureError> {
+    reader
+        .join()
+        .map_err(|_| capture_error("process output reader panicked"))?
+        .map_err(CaptureError::Capture)
+}
+
+fn join_writer(writer: WriterHandle) -> Result<(), CaptureError> {
+    writer
+        .join()
+        .map_err(|_| capture_error("process input writer panicked"))?
+        .map_err(CaptureError::WriteInput)
+}

--- a/crates/process/src/error.rs
+++ b/crates/process/src/error.rs
@@ -1,0 +1,18 @@
+use std::io;
+use std::time::Duration;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CaptureError {
+    #[error("Failed to capture process output.")]
+    Capture(#[source] io::Error),
+
+    #[error("Process output exceeded the {limit}-byte limit.")]
+    OutputLimitExceeded { limit: usize },
+
+    #[error("Process exceeded its {timeout:?} timeout.")]
+    Timeout { timeout: Duration },
+
+    #[error("Failed to write process input.")]
+    WriteInput(#[source] io::Error),
+}

--- a/crates/process/src/lib.rs
+++ b/crates/process/src/lib.rs
@@ -1,0 +1,5 @@
+mod capture;
+mod error;
+
+pub use capture::{CaptureOptions, FileOutput, Output, capture_output, capture_output_to_files};
+pub use error::CaptureError;

--- a/crates/process/tests/capture_test.rs
+++ b/crates/process/tests/capture_test.rs
@@ -1,0 +1,202 @@
+#![cfg(unix)]
+
+use starbase_process::{CaptureError, CaptureOptions, capture_output, capture_output_to_files};
+use std::fs::File;
+use std::process::Command;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+fn create_command(script: &str) -> Command {
+    let mut command = Command::new("sh");
+    command.args(["-c", script]);
+    command
+}
+
+fn create_output_files() -> (std::path::PathBuf, File, std::path::PathBuf, File) {
+    static NEXT_ID: AtomicUsize = AtomicUsize::new(0);
+
+    let id = NEXT_ID.fetch_add(1, Ordering::Relaxed);
+    let prefix = format!("starbase-process-{}-{id}", std::process::id());
+    let stdout_path = std::env::temp_dir().join(format!("{prefix}-stdout"));
+    let stderr_path = std::env::temp_dir().join(format!("{prefix}-stderr"));
+    let stdout = File::create(&stdout_path).unwrap();
+    let stderr = File::create(&stderr_path).unwrap();
+
+    (stdout_path, stdout, stderr_path, stderr)
+}
+
+#[test]
+fn captures_stdout_and_stderr() {
+    let output = capture_output(
+        &mut create_command("printf 'out'; printf 'err' 1>&2"),
+        None,
+        &CaptureOptions::default(),
+    )
+    .unwrap();
+
+    assert!(output.status.success());
+    assert_eq!(output.stdout, b"out");
+    assert_eq!(output.stderr, b"err");
+}
+
+#[test]
+fn passes_input_to_stdin() {
+    let output = capture_output(
+        &mut create_command("cat"),
+        Some(b"hello world".to_vec()),
+        &CaptureOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(output.stdout, b"hello world");
+}
+
+#[test]
+fn enforces_timeout() {
+    let error = capture_output(
+        &mut create_command("sleep 30"),
+        None,
+        &CaptureOptions {
+            timeout: Some(Duration::from_millis(50)),
+            ..CaptureOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, CaptureError::Timeout { .. }));
+}
+
+#[test]
+fn enforces_combined_output_limit() {
+    let error = capture_output(
+        &mut create_command("printf '12345'; printf '67890' 1>&2"),
+        None,
+        &CaptureOptions {
+            output_limit: Some(8),
+            ..CaptureOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        CaptureError::OutputLimitExceeded { limit: 8 }
+    ));
+}
+
+#[test]
+fn never_returns_truncated_output_at_the_limit() {
+    for _ in 0..100 {
+        let result = capture_output(
+            &mut create_command("printf '123456789'"),
+            None,
+            &CaptureOptions {
+                output_limit: Some(8),
+                ..CaptureOptions::default()
+            },
+        );
+
+        assert!(matches!(
+            result.unwrap_err(),
+            CaptureError::OutputLimitExceeded { limit: 8 }
+        ));
+    }
+}
+
+#[test]
+fn timeout_terminates_descendants_holding_output_pipes() {
+    let error = capture_output(
+        &mut create_command("sleep 30 & printf 'ready'"),
+        None,
+        &CaptureOptions {
+            timeout: Some(Duration::from_millis(50)),
+            ..CaptureOptions::default()
+        },
+    )
+    .unwrap_err();
+
+    assert!(matches!(error, CaptureError::Timeout { .. }));
+}
+
+#[test]
+fn completion_terminates_detached_descendants() {
+    let output = capture_output(
+        &mut create_command("sleep 30 >/dev/null 2>&1 & printf $!"),
+        None,
+        &CaptureOptions::default(),
+    )
+    .unwrap();
+    let pid = std::str::from_utf8(&output.stdout)
+        .unwrap()
+        .parse::<i32>()
+        .unwrap();
+
+    for _ in 0..20 {
+        if unsafe { libc::kill(pid, 0) } == -1
+            && std::io::Error::last_os_error().raw_os_error() == Some(libc::ESRCH)
+        {
+            return;
+        }
+
+        std::thread::sleep(Duration::from_millis(10));
+    }
+
+    panic!("descendant process {pid} survived capture completion");
+}
+
+#[test]
+fn preserves_non_utf8_bytes() {
+    let output = capture_output(
+        &mut create_command(r"printf 'a\377b'"),
+        None,
+        &CaptureOptions::default(),
+    )
+    .unwrap();
+
+    assert_eq!(output.stdout, b"a\xffb");
+}
+
+#[test]
+fn captures_output_to_files() {
+    let (stdout_path, stdout, stderr_path, stderr) = create_output_files();
+    let output = capture_output_to_files(
+        &mut create_command("printf 'out'; printf 'err' 1>&2"),
+        None,
+        &CaptureOptions::default(),
+        stdout,
+        stderr,
+    )
+    .unwrap();
+
+    assert_eq!(output.stdout_len, 3);
+    assert_eq!(output.stderr_len, 3);
+    assert_eq!(std::fs::read(&stdout_path).unwrap(), b"out");
+    assert_eq!(std::fs::read(&stderr_path).unwrap(), b"err");
+
+    std::fs::remove_file(stdout_path).unwrap();
+    std::fs::remove_file(stderr_path).unwrap();
+}
+
+#[test]
+fn enforces_output_limit_when_capturing_to_files() {
+    let (stdout_path, stdout, stderr_path, stderr) = create_output_files();
+    let error = capture_output_to_files(
+        &mut create_command("printf '123456789'"),
+        None,
+        &CaptureOptions {
+            output_limit: Some(8),
+            ..CaptureOptions::default()
+        },
+        stdout,
+        stderr,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        error,
+        CaptureError::OutputLimitExceeded { limit: 8 }
+    ));
+
+    std::fs::remove_file(stdout_path).unwrap();
+    std::fs::remove_file(stderr_path).unwrap();
+}


### PR DESCRIPTION
Adds a process crate to starbase for managing child process execution. Handles bounding, and process tree clean up